### PR TITLE
Add desktop notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,24 @@ Wayland-native Speech-to-Text daemon using Google Gemini API.
 - **PipeWire/PulseAudio**: Supports both `pw-record` and `parecord` for audio recording
 - **Signal-based control**: Toggle recording via `SIGUSR1` signal
 - **State machine**: Clean state transitions (IDLE → RECORDING → TRANSCRIBING → TYPING)
+- **Desktop notifications**: Visual feedback for each state transition
 - **Google Gemini**: Fast transcription using Gemini 2.0 Flash
+
+## Requirements
+
+### Python
+- **Python 3.14+** is required
+
+### Package Manager
+- **[uv](https://docs.astral.sh/uv/)** - Fast Python package manager and installer
+
+### System Tools
+- **wtype** - Wayland text input simulation
+- **wl-clipboard** - Wayland clipboard utilities (provides `wl-copy`)
+- **pipewire-utils** or **pulseaudio-utils** - Audio recording (`pw-record` or `parecord`)
+- **libnotify** - Desktop notification support (provides `notify-send`)
+
+See the [Dependencies](#dependencies) section below for installation commands.
 
 ## Installation
 
@@ -70,13 +87,13 @@ export GEMINI_API_KEY=your_api_key_here
 ### System packages (Fedora/RHEL)
 
 ```bash
-sudo dnf install pipewire-utils wtype wl-clipboard
+sudo dnf install pipewire-utils wtype wl-clipboard libnotify
 ```
 
 ### System packages (Debian/Ubuntu)
 
 ```bash
-sudo apt install pipewire-audio wtype wl-clipboard
+sudo apt install pipewire-audio wtype wl-clipboard libnotify-bin
 ```
 
 ## Usage
@@ -119,10 +136,12 @@ kill -TERM $(cat $XDG_RUNTIME_DIR/stt-wayland.pid)
 
 ## Workflow
 
-1. **First SIGUSR1**: Start recording (IDLE → RECORDING)
-2. **Second SIGUSR1**: Stop recording and transcribe (RECORDING → TRANSCRIBING → TYPING)
-3. **Auto-type**: Transcribed text is automatically typed using `wtype`
+1. **First SIGUSR1**: Start recording (IDLE → RECORDING) - notification shown
+2. **Second SIGUSR1**: Stop recording and transcribe (RECORDING → TRANSCRIBING) - notification shown
+3. **Auto-type**: Transcribed text is automatically typed using `wtype` - success notification shown
 4. **Return to IDLE**: Ready for next recording
+
+Desktop notifications appear at each stage to provide visual feedback on the current state.
 
 ## State Machine
 

--- a/src/stt_wayland/output/__init__.py
+++ b/src/stt_wayland/output/__init__.py
@@ -1,6 +1,19 @@
 """Text output module."""
 
 from .clipboard import copy_to_clipboard
+from .notify import (
+    notify_error,
+    notify_recording_started,
+    notify_recording_stopped,
+    notify_transcription_complete,
+)
 from .wtype import type_text
 
-__all__ = ["copy_to_clipboard", "type_text"]
+__all__ = [
+    "copy_to_clipboard",
+    "type_text",
+    "notify_error",
+    "notify_recording_started",
+    "notify_recording_stopped",
+    "notify_transcription_complete",
+]

--- a/src/stt_wayland/output/notify.py
+++ b/src/stt_wayland/output/notify.py
@@ -1,0 +1,108 @@
+"""Desktop notification module using notify-send."""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Final
+
+_logger = logging.getLogger(__name__)
+
+# Notification configuration
+NOTIFY_SEND: Final[str] = "notify-send"
+APP_NAME: Final[str] = "STT Wayland"
+ICON_RECORDING: Final[str] = "audio-input-microphone"
+ICON_PROCESSING: Final[str] = "system-run"
+ICON_COMPLETE: Final[str] = "emblem-default"
+ICON_ERROR: Final[str] = "dialog-error"
+URGENCY_NORMAL: Final[str] = "normal"
+URGENCY_CRITICAL: Final[str] = "critical"
+
+
+def _send_notification(
+    summary: str,
+    body: str = "",
+    icon: str = "",
+    urgency: str = URGENCY_NORMAL,
+) -> None:
+    """Send a desktop notification using notify-send.
+
+    Args:
+        summary: Notification title.
+        body: Notification body text.
+        icon: Icon name from freedesktop icon theme.
+        urgency: Notification urgency level (low, normal, critical).
+
+    Note:
+        Non-blocking operation. Errors are logged but don't raise exceptions.
+
+    """
+    cmd = [NOTIFY_SEND, "--app-name", APP_NAME]
+
+    if icon:
+        cmd.extend(["--icon", icon])
+
+    cmd.extend(["--urgency", urgency])
+    cmd.extend([summary, body])
+
+    try:
+        subprocess.run(
+            cmd,
+            check=False,
+            capture_output=True,
+            timeout=5,
+        )
+    except subprocess.TimeoutExpired:
+        _logger.warning("notify-send timeout: %s", summary)
+    except FileNotFoundError:
+        _logger.warning("notify-send not found, notifications disabled")
+    except Exception:
+        _logger.exception("Failed to send notification: %s", summary)
+
+
+def notify_recording_started() -> None:
+    """Show 'Recording...' notification."""
+    _send_notification(
+        summary="Recording",
+        body="Speech recording in progress",
+        icon=ICON_RECORDING,
+        urgency=URGENCY_NORMAL,
+    )
+
+
+def notify_recording_stopped() -> None:
+    """Show 'Processing...' notification."""
+    _send_notification(
+        summary="Processing",
+        body="Transcribing audio...",
+        icon=ICON_PROCESSING,
+        urgency=URGENCY_NORMAL,
+    )
+
+
+def notify_transcription_complete() -> None:
+    """Show 'Done' notification."""
+    _send_notification(
+        summary="Transcription Complete",
+        body="Text typed successfully",
+        icon=ICON_COMPLETE,
+        urgency=URGENCY_NORMAL,
+    )
+
+
+def notify_error(message: str) -> None:
+    """Show error notification.
+
+    Args:
+        message: Error message to display.
+
+    """
+    _send_notification(
+        summary="STT Error",
+        body=message,
+        icon=ICON_ERROR,
+        urgency=URGENCY_CRITICAL,
+    )


### PR DESCRIPTION
## Summary
- Adds desktop notification support for recording state changes
- Notifies users on recording start/stop and errors
- Uses notify-send for cross-desktop compatibility

## Test plan
- [ ] Verify notifications appear on recording start
- [ ] Verify notifications appear on recording stop
- [ ] Verify error notifications display properly
- [ ] Test on different desktop environments (GNOME, KDE, etc.)