### PR TITLE
feat: add --refine flag for AI-based typo correction

### DIFF
--- a/src/stt_wayland/__main__.py
+++ b/src/stt_wayland/__main__.py
@@ -1,11 +1,25 @@
 """Entry point for stt-daemon command."""
 
+import argparse
+
 from .daemon import run
 
 
 def main() -> None:
     """Run the STT daemon."""
-    run()
+    parser = argparse.ArgumentParser(
+        description="Speech-to-Text daemon for Wayland",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--refine",
+        action="store_true",
+        default=False,
+        help="Enable AI-based typo and grammar correction on transcribed text (default: disabled)",
+    )
+
+    args = parser.parse_args()
+    run(refine=args.refine)
 
 
 if __name__ == "__main__":

--- a/src/stt_wayland/daemon.py
+++ b/src/stt_wayland/daemon.py
@@ -33,11 +33,12 @@ ERR_CONFIG: Final[str] = "GEMINI_API_KEY environment variable is required. Set i
 class STTDaemon:
     """Speech-to-Text daemon for Wayland."""
 
-    def __init__(self, config: Config) -> None:
+    def __init__(self, config: Config, *, refine: bool = False) -> None:
         """Initialize daemon.
 
         Args:
             config: Daemon configuration.
+            refine: Enable AI-based typo and grammar correction.
 
         """
         self.config = config
@@ -46,6 +47,7 @@ class STTDaemon:
         self.transcriber = GeminiTranscriber(
             api_key=config.api_key,
             model=config.model,
+            refine=refine,
         )
         self._logger = logging.getLogger(__name__)
         self._audio_path: Path | None = None
@@ -293,8 +295,13 @@ class STTDaemon:
         self._logger.info("Daemon stopped")
 
 
-def run() -> NoReturn:
-    """Run the STT daemon."""
+def run(*, refine: bool = False) -> NoReturn:
+    """Run the STT daemon.
+
+    Args:
+        refine: Enable AI-based typo and grammar correction.
+
+    """
     # Setup logging
     logging.basicConfig(
         level=logging.INFO,
@@ -312,5 +319,5 @@ def run() -> NoReturn:
         logger.exception("Configuration error")
         sys.exit(1)
 
-    daemon = STTDaemon(config)
+    daemon = STTDaemon(config, refine=refine)
     daemon.run()

--- a/src/stt_wayland/transcription/gemini.py
+++ b/src/stt_wayland/transcription/gemini.py
@@ -15,9 +15,32 @@ if TYPE_CHECKING:
 ERR_EMPTY_RESPONSE: Final[str] = "Empty transcription response"
 ERR_NO_SPEECH: Final[str] = "No speech detected in audio"
 TRANSCRIPTION_PROMPT: Final[str] = (
+    "Transcribe the spoken words in this audio file.\n\n"
+    "STRICT OUTPUT RULES:\n"
+    "- Return ONLY the transcribed words exactly as spoken\n"
+    "- NO explanations whatsoever\n"
+    "- NO prefixes like 'The user said' or 'Here is the transcription' or 'The speaker said'\n"
+    "- NO meta-commentary or descriptions\n"
+    "- NO markdown formatting or code blocks\n"
+    "- NO quotation marks around the output\n"
+    "- Output the raw text directly with no wrapping\n"
+    "- If audio is empty, silent, or unclear, return exactly: [NO_SPEECH]\n\n"
+    "CRITICAL: Your entire response must be ONLY the spoken words. Nothing else."
+)
+TRANSCRIPTION_PROMPT_WITH_REFINEMENT: Final[str] = (
     "Transcribe the spoken words in this audio file. "
-    "Output ONLY the exact words spoken, nothing else. "
-    "If the audio is silent or contains no speech, respond with exactly: [NO_SPEECH]"
+    "After transcription, refine the text by correcting any typos, grammatical errors, "
+    "and improving clarity while preserving the original meaning.\n\n"
+    "STRICT OUTPUT RULES:\n"
+    "- Return ONLY the refined transcribed text\n"
+    "- NO explanations whatsoever\n"
+    "- NO prefixes like 'The corrected version is' or 'Here is the refined text'\n"
+    "- NO meta-commentary about what you corrected or changed\n"
+    "- NO markdown formatting or code blocks\n"
+    "- NO quotation marks around the output\n"
+    "- Output the clean refined text directly with no wrapping\n"
+    "- If audio is empty, silent, or unclear, return exactly: [NO_SPEECH]\n\n"
+    "CRITICAL: Your entire response must be ONLY the refined transcribed words. Nothing else."
 )
 
 
@@ -36,16 +59,18 @@ def _raise_no_speech_error() -> NoReturn:
 class GeminiTranscriber:
     """Transcribes audio using Google Gemini API."""
 
-    def __init__(self, api_key: str, model: str = "gemini-2.5-flash") -> None:
+    def __init__(self, api_key: str, model: str = "gemini-2.5-flash", *, refine: bool = False) -> None:
         """Initialize Gemini transcriber.
 
         Args:
             api_key: Google API key.
             model: Model name to use.
+            refine: Enable AI-based typo and grammar correction.
 
         """
         self._client = genai.Client(api_key=api_key)
         self._model = model
+        self._refine = refine
         self._logger = logging.getLogger(__name__)
 
     def transcribe(self, audio_path: Path) -> str:
@@ -61,7 +86,8 @@ class GeminiTranscriber:
             RuntimeError: If transcription fails.
 
         """
-        self._logger.info("Transcribing %s with %s", audio_path, self._model)
+        refine_mode = "with refinement" if self._refine else "raw transcription"
+        self._logger.info("Transcribing %s with %s (%s)", audio_path, self._model, refine_mode)
 
         try:
             # Upload audio file
@@ -71,11 +97,14 @@ class GeminiTranscriber:
             # Create audio part
             audio_part = types.Part.from_bytes(data=audio_data, mime_type="audio/wav")
 
+            # Select prompt based on refine setting
+            prompt = TRANSCRIPTION_PROMPT_WITH_REFINEMENT if self._refine else TRANSCRIPTION_PROMPT
+
             # Generate content with audio
             response = self._client.models.generate_content(
                 model=self._model,
                 contents=[
-                    types.Part.from_text(text=TRANSCRIPTION_PROMPT),
+                    types.Part.from_text(text=prompt),
                     audio_part,
                 ],
             )


### PR DESCRIPTION
## Summary
- Add `--refine` CLI flag to enable AI-based typo and grammar correction on transcribed text
- Implement strict output rules to prevent AI from adding explanations or meta-commentary
- Maintain backward compatibility - default behavior unchanged

## Changes
- `src/stt_wayland/__main__.py` - Added argparse CLI with `--refine` flag
- `src/stt_wayland/daemon.py` - Added refine parameter passing through the daemon
- `src/stt_wayland/transcription/gemini.py` - Added strict prompts for both modes

## Usage
```bash
stt-daemon           # Default (no refinement)
stt-daemon --refine  # With AI refinement enabled
```

## Test plan
- [x] All 53 existing tests pass
- [ ] Manual test: run `stt-daemon` and verify default transcription works
- [ ] Manual test: run `stt-daemon --refine` and verify typo correction works