### PR TITLE
feat: add --ask-keyword flag for voice-to-AI-response mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Wayland-native Speech-to-Text daemon using Google Gemini API.
 - **Google Gemini**: Fast transcription using Gemini 2.0 Flash
 - **AI refinement**: Optional typo and grammar correction via `--refine`
 - **Inline AI instructions**: Speak custom AI instructions using a keyword separator
+- **Voice query mode**: Ask AI questions and get answers typed out via `--ask-keyword`
 
 ## Requirements
 
@@ -156,6 +157,26 @@ stt-daemon --instruction-keyword boom
 - If no keyword is detected in your speech, the text is output as-is
 - You can combine with `--refine`: `stt-daemon --refine --instruction-keyword boom`
 
+### `--ask-keyword KEYWORD`
+
+Enable voice query mode by specifying a trigger keyword. When your speech STARTS with the keyword, the rest is sent to the AI as a question, and the AI's ANSWER is typed out instead of your original words.
+
+```bash
+stt-daemon --ask-keyword hey
+```
+
+**Example:**
+- You say: "hey what is the capital of France"
+- The system types: "The capital of France is Paris"
+
+**Notes:**
+- The keyword must be at the START of your speech
+- Keyword matching is case-insensitive ("hey", "HEY", "Hey" all work)
+- Word boundaries are respected ("heyo" will NOT trigger for keyword "hey")
+- If keyword is spoken alone without a query, nothing is typed
+- You can combine with other flags: `stt-daemon --ask-keyword hey --instruction-keyword boom`
+- When both keywords are configured, `--ask-keyword` takes precedence (checked first)
+
 ### Stop the daemon
 
 ```bash
@@ -198,6 +219,12 @@ exec env GEMINI_API_KEY="<YOUR_KEY>" $HOME/.local/bin/stt-daemon --refine
 
 # With inline AI instructions (say "boom" to give AI instructions)
 exec env GEMINI_API_KEY="<YOUR_KEY>" $HOME/.local/bin/stt-daemon --instruction-keyword boom
+
+# With voice query mode (say "hey" at start to ask AI questions)
+exec env GEMINI_API_KEY="<YOUR_KEY>" $HOME/.local/bin/stt-daemon --ask-keyword hey
+
+# Combined: voice queries + inline instructions
+exec env GEMINI_API_KEY="<YOUR_KEY>" $HOME/.local/bin/stt-daemon --ask-keyword hey --instruction-keyword boom
 
 # Press Super+R to toggle: first press starts recording, second press stops and transcribes
 bindsym $mod+r exec pkill -USR1 stt-daemon

--- a/src/stt_wayland/__main__.py
+++ b/src/stt_wayland/__main__.py
@@ -23,9 +23,15 @@ def main() -> None:
         default=None,
         help="Keyword to separate content from AI instructions (e.g., 'boom'). If not set, feature is disabled.",
     )
+    parser.add_argument(
+        "--ask-keyword",
+        type=str,
+        default=None,
+        help="Keyword at start of speech triggers AI query mode - AI's answer is typed instead of transcription",
+    )
 
     args = parser.parse_args()
-    run(refine=args.refine, instruction_keyword=args.instruction_keyword)
+    run(refine=args.refine, instruction_keyword=args.instruction_keyword, ask_keyword=args.ask_keyword)
 
 
 if __name__ == "__main__":

--- a/src/stt_wayland/daemon.py
+++ b/src/stt_wayland/daemon.py
@@ -33,13 +33,21 @@ ERR_CONFIG: Final[str] = "GEMINI_API_KEY environment variable is required. Set i
 class STTDaemon:
     """Speech-to-Text daemon for Wayland."""
 
-    def __init__(self, config: Config, *, refine: bool = False, instruction_keyword: str | None = None) -> None:
+    def __init__(
+        self,
+        config: Config,
+        *,
+        refine: bool = False,
+        instruction_keyword: str | None = None,
+        ask_keyword: str | None = None,
+    ) -> None:
         """Initialize daemon.
 
         Args:
             config: Daemon configuration.
             refine: Enable AI-based typo and grammar correction.
             instruction_keyword: Keyword to separate content from AI instructions.
+            ask_keyword: Keyword at start of speech to trigger AI query mode.
 
         """
         self.config = config
@@ -50,6 +58,7 @@ class STTDaemon:
             model=config.model,
             refine=refine,
             instruction_keyword=instruction_keyword,
+            ask_keyword=ask_keyword,
         )
         self._logger = logging.getLogger(__name__)
         self._audio_path: Path | None = None
@@ -297,12 +306,18 @@ class STTDaemon:
         self._logger.info("Daemon stopped")
 
 
-def run(*, refine: bool = False, instruction_keyword: str | None = None) -> NoReturn:
+def run(
+    *,
+    refine: bool = False,
+    instruction_keyword: str | None = None,
+    ask_keyword: str | None = None,
+) -> NoReturn:
     """Run the STT daemon.
 
     Args:
         refine: Enable AI-based typo and grammar correction.
         instruction_keyword: Keyword to separate content from AI instructions.
+        ask_keyword: Keyword at start of speech to trigger AI query mode.
 
     """
     # Setup logging
@@ -322,5 +337,5 @@ def run(*, refine: bool = False, instruction_keyword: str | None = None) -> NoRe
         logger.exception("Configuration error")
         sys.exit(1)
 
-    daemon = STTDaemon(config, refine=refine, instruction_keyword=instruction_keyword)
+    daemon = STTDaemon(config, refine=refine, instruction_keyword=instruction_keyword, ask_keyword=ask_keyword)
     daemon.run()


### PR DESCRIPTION
## Summary
- Add `--ask-keyword` flag that enables voice query mode
- When user starts speaking with the trigger keyword, the rest is sent to AI as a prompt
- The AI's answer is typed instead of the user's original words

## Changes
- Add `--ask-keyword` CLI argument in `__main__.py`
- Pass parameter through `daemon.py` to `GeminiTranscriber`
- Implement `_parse_ask_query()` and `_answer_query()` methods in `gemini.py`
- Ask-keyword takes precedence over instruction-keyword when both are set
- Add 26 new tests (unit + integration) - total 113 tests passing
- Update README with documentation and usage examples

## Example
```bash
stt-daemon --ask-keyword hey
# User says: "hey what is the capital of France"
# Types: "The capital of France is Paris"
```

## Test plan
- [x] All 113 tests pass
- [x] Pyright type checking passes
- [x] Ruff linting passes
- [x] Code review completed

Closes #5