### PR TITLE
fix: resolve memory leaks causing 18GB usage in long-running daemon

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Wayland-native Speech-to-Text daemon using Google Gemini API.
 - **AI refinement**: Optional typo and grammar correction via `--refine`
 - **Inline AI instructions**: Speak custom AI instructions using a keyword separator
 - **Voice query mode**: Ask AI questions and get answers typed out via `--ask-keyword`
+- **Live streaming**: Real-time transcription while recording via `--live` (streams audio to Gemini Live API as you speak)
+- **Max recording duration**: Auto-stops recording after 5 minutes (configurable via `STT_MAX_RECORDING`)
 
 ## Requirements
 
@@ -79,7 +81,8 @@ Create a `.env` file in the project root:
 
 ```env
 GEMINI_API_KEY=your_api_key_here
-STT_MODEL=gemini-2.5-flash  # Optional, this is the default
+STT_MODEL=gemini-2.5-flash       # Optional, this is the default
+STT_MAX_RECORDING=300             # Optional, max recording duration in seconds (default: 300 = 5 minutes)
 ```
 
 Or export the environment variable:
@@ -87,6 +90,18 @@ Or export the environment variable:
 ```bash
 export GEMINI_API_KEY=your_api_key_here
 ```
+
+### Logging
+
+Logs are written to both stdout and a rotating log file:
+
+```
+~/.local/share/stt-wayland/stt-daemon.log
+```
+
+- **Max file size**: 5 MB per file
+- **Backups**: 3 rotated files (`stt-daemon.log.1`, `.2`, `.3`)
+- Logs include timestamps, levels, and memory usage (every ~60 seconds)
 
 ## Dependencies
 
@@ -197,6 +212,32 @@ stt-daemon --ask-keyword hey
 - You can combine with other flags: `stt-daemon --ask-keyword hey --instruction-keyword boom`
 - When both keywords are configured, `--ask-keyword` takes precedence (checked first)
 
+### `--live`
+
+Enable real-time streaming transcription using the Gemini Live API. Instead of recording a complete audio file and then uploading it, audio is streamed to the API in real-time while you speak.
+
+```bash
+stt-daemon --live
+```
+
+**How it works:**
+- When recording starts, a WebSocket connection opens to the Gemini Live API
+- Audio chunks (raw PCM, 16kHz) are streamed to the API as they are captured
+- When recording stops, the transcription result is collected immediately
+- Uses `gemini-3.1-flash-live-preview` model by default (override with `STT_MODEL`)
+
+**Benefits:**
+- Faster results — transcription begins while you're still speaking
+- Lower memory usage — no large WAV file buffered in memory
+- Better for long recordings — audio is processed incrementally
+
+**Combine with other flags:**
+```bash
+stt-daemon --live --refine
+stt-daemon --live --ask-keyword hey
+stt-daemon --live --refine --format --instruction-keyword boom
+```
+
 ### Stop the daemon
 
 ```bash
@@ -212,7 +253,7 @@ kill -TERM $(cat $XDG_RUNTIME_DIR/stt-wayland.pid)
 ## Workflow
 
 1. **First SIGUSR1**: Start recording (IDLE → RECORDING) - notification shown
-2. **Second SIGUSR1**: Stop recording and transcribe (RECORDING → TRANSCRIBING) - notification shown
+2. **Second SIGUSR1** (or auto-stop after max duration): Stop recording and transcribe (RECORDING → TRANSCRIBING) - notification shown
 3. **Auto-type**: Transcribed text is typed via `wtype` (or pasted via clipboard for multi-line output) - success notification shown
 4. **Return to IDLE**: Ready for next recording
 
@@ -221,6 +262,8 @@ Desktop notifications appear at each stage to provide visual feedback on the cur
 ## State Machine
 
 ```
+                                ┌──max duration──┐
+                                ↓                │
 IDLE ──SIGUSR1──→ RECORDING ──SIGUSR1──→ TRANSCRIBING ──auto──→ TYPING ──auto──→ IDLE
   ↑                                                                              │
   └──────────────────────────────────────────────────────────────────────────────┘
@@ -249,6 +292,12 @@ exec env GEMINI_API_KEY="<YOUR_KEY>" $HOME/.local/bin/stt-daemon --ask-keyword h
 # Combined: voice queries + inline instructions
 exec env GEMINI_API_KEY="<YOUR_KEY>" $HOME/.local/bin/stt-daemon --ask-keyword hey --instruction-keyword boom
 
+# Live streaming mode (real-time transcription)
+exec env GEMINI_API_KEY="<YOUR_KEY>" $HOME/.local/bin/stt-daemon --live
+
+# Live streaming with refinement and voice queries
+exec env GEMINI_API_KEY="<YOUR_KEY>" $HOME/.local/bin/stt-daemon --live --refine --ask-keyword hey
+
 # Press Super+R to toggle: first press starts recording, second press stops and transcribes
 bindsym $mod+r exec pkill -USR1 stt-daemon
 ```
@@ -263,7 +312,8 @@ src/stt_wayland/
 ├── audio/
 │   └── recorder.py     # pw-record/parecord wrapper
 ├── transcription/
-│   └── gemini.py       # Google Gemini API client
+│   ├── gemini.py       # Google Gemini API client (batch mode)
+│   └── gemini_live.py  # Google Gemini Live API client (real-time streaming)
 └── output/
     ├── wtype.py        # wtype text output and clipboard paste
     └── clipboard.py    # wl-copy clipboard operations

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,3 +73,9 @@ omit = ["*/tests/*", "*/__pycache__/*", "*/.venv/*"]
 precision = 2
 show_missing = true
 skip_covered = false
+
+[dependency-groups]
+dev = [
+    "mypy>=2.0.0",
+    "ruff>=0.15.12",
+]

--- a/src/stt_wayland/audio/recorder.py
+++ b/src/stt_wayland/audio/recorder.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import logging
+import queue
 import shutil
 import subprocess
+import threading
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -127,6 +129,109 @@ class AudioRecorder:
 
         self._logger.info("Recording saved: %s", self.output_path)
         return self.output_path
+
+    def start_streaming(self) -> None:
+        """Start audio recording in streaming mode (raw PCM to stdout).
+
+        Audio chunks are buffered internally and can be read via read_chunk().
+
+        Raises:
+            RuntimeError: If already recording.
+
+        """
+        if self._process is not None:
+            msg = ERR_ALREADY_RECORDING
+            raise RuntimeError(msg)
+
+        # For streaming, we output raw PCM to stdout instead of WAV to file
+        if self._recorder_cmd == "pw-record":
+            cmd = [
+                "pw-record",
+                "--rate",
+                "16000",
+                "--channels",
+                "1",
+                "--format",
+                "s16",
+                "-",  # stdout
+            ]
+        else:  # parecord
+            cmd = [
+                "parecord",
+                "--rate=16000",
+                "--channels=1",
+                "--format=s16le",
+                "--raw",
+            ]
+
+        self._logger.info("Starting streaming recording: %s", " ".join(cmd))
+        self._chunk_queue: queue.Queue[bytes | None] = queue.Queue(maxsize=100)
+        self._process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)  # noqa: S603
+
+        # Background thread to read chunks from recorder stdout
+        self._reader_thread = threading.Thread(
+            target=self._read_audio_chunks,
+            daemon=True,
+            name="audio-chunk-reader",
+        )
+        self._reader_thread.start()
+
+    def _read_audio_chunks(self) -> None:
+        """Read PCM chunks from recorder stdout and put them in the queue."""
+        assert self._process is not None  # noqa: S101
+        assert self._process.stdout is not None  # noqa: S101
+        try:
+            while True:
+                chunk = self._process.stdout.read(32768)  # 32KB chunks
+                if not chunk:
+                    break
+                try:
+                    self._chunk_queue.put(chunk, timeout=1.0)
+                except queue.Full:
+                    self._logger.warning("Audio chunk queue full, dropping chunk")
+        except Exception:
+            self._logger.exception("Error reading audio chunks")
+        finally:
+            self._chunk_queue.put(None)  # Sentinel to signal end of stream
+
+    def read_chunk(self, timeout: float = 1.0) -> bytes | None:
+        """Read the next audio chunk from the streaming buffer.
+
+        Args:
+            timeout: Maximum time to wait for a chunk.
+
+        Returns:
+            Raw PCM audio data, or None if the stream has ended.
+
+        """
+        try:
+            return self._chunk_queue.get(timeout=timeout)
+        except queue.Empty:
+            return b""
+
+    def stop_streaming(self) -> None:
+        """Stop streaming recording.
+
+        Raises:
+            RuntimeError: If not recording.
+
+        """
+        if self._process is None:
+            msg = ERR_NO_RECORDING
+            raise RuntimeError(msg)
+
+        self._logger.info("Stopping streaming recording")
+        self._process.terminate()
+
+        try:
+            self._process.communicate(timeout=5)
+        except subprocess.TimeoutExpired:
+            self._logger.warning("Recorder did not terminate, killing")
+            self._process.kill()
+            self._process.communicate()
+
+        self._process = None
+        self._logger.info("Streaming recording stopped")
 
     def is_recording(self) -> bool:
         """Check if currently recording.

--- a/src/stt_wayland/config.py
+++ b/src/stt_wayland/config.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
 
 ERR_NO_API_KEY: Final[str] = "GEMINI_API_KEY environment variable is required. Set it in .env or export it."
 LIVE_MODEL_DEFAULT: Final[str] = "gemini-3.1-flash-live-preview"
+MAX_RECORDING_DURATION_DEFAULT: Final[float] = 300.0  # 5 minutes
 
 
 @dataclass(frozen=True, slots=True)
@@ -23,6 +24,7 @@ class Config:
     api_key: str
     model: str
     runtime_dir: Path
+    max_recording_duration: float
 
     @classmethod
     def from_env(cls) -> Self:
@@ -44,7 +46,23 @@ class Config:
         runtime_dir_str = os.getenv("XDG_RUNTIME_DIR")
         runtime_dir = Path("/tmp") if not runtime_dir_str else Path(runtime_dir_str)  # noqa: S108
 
-        return cls(api_key=api_key, model=model, runtime_dir=runtime_dir)
+        max_recording_str = os.getenv("STT_MAX_RECORDING")
+        if max_recording_str:
+            try:
+                max_recording_duration = float(max_recording_str)
+            except ValueError:
+                max_recording_duration = MAX_RECORDING_DURATION_DEFAULT
+            if max_recording_duration <= 0:
+                max_recording_duration = MAX_RECORDING_DURATION_DEFAULT
+        else:
+            max_recording_duration = MAX_RECORDING_DURATION_DEFAULT
+
+        return cls(
+            api_key=api_key,
+            model=model,
+            runtime_dir=runtime_dir,
+            max_recording_duration=max_recording_duration,
+        )
 
     @property
     def pid_file(self) -> Path:

--- a/src/stt_wayland/daemon.py
+++ b/src/stt_wayland/daemon.py
@@ -7,16 +7,19 @@ import logging
 import os
 import signal
 import sys
+import time
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
 from typing import TYPE_CHECKING, NoReturn
 
 if TYPE_CHECKING:
-    from pathlib import Path
     from typing import Final
 
 from .audio import AudioRecorder
 from .config import LIVE_MODEL_DEFAULT, Config
 from .output import (
     notify_error,
+    notify_recording_auto_stopped,
     notify_recording_started,
     notify_recording_stopped,
     notify_transcription_complete,
@@ -82,6 +85,8 @@ class STTDaemon:
         self._logger = logging.getLogger(__name__)
         self._audio_path: Path | None = None
         self._transcribed_text: str | None = None
+        self._recording_start_time: float | None = None
+        self._live = live
 
         # Signal flags (async-safe)
         self._toggle_requested = False
@@ -191,7 +196,12 @@ class STTDaemon:
         """Start recording (IDLE → RECORDING)."""
         self._logger.info("Starting recording")
         try:
-            self.recorder.start_recording()
+            if self._live:
+                self.recorder.start_streaming()
+                self.transcriber.start_streaming(self.recorder)
+            else:
+                self.recorder.start_recording()
+            self._recording_start_time = time.monotonic()
             self.state_machine.set_state(State.RECORDING)
             notify_recording_started()
         except Exception:
@@ -202,8 +212,12 @@ class STTDaemon:
     def _stop_recording(self) -> None:
         """Stop recording (RECORDING → TRANSCRIBING)."""
         self._logger.info("Stopping recording")
+        self._recording_start_time = None
         try:
-            self._audio_path = self.recorder.stop_recording()
+            if self._live:
+                self.recorder.stop_streaming()
+            else:
+                self._audio_path = self.recorder.stop_recording()
             self.state_machine.set_state(State.TRANSCRIBING)
             notify_recording_stopped()
             # Immediately trigger transcription
@@ -214,7 +228,10 @@ class STTDaemon:
             # Ensure recorder is stopped on error
             if self.recorder.is_recording():
                 try:
-                    self.recorder.stop_recording()
+                    if self._live:
+                        self.recorder.stop_streaming()
+                    else:
+                        self.recorder.stop_recording()
                 except Exception:
                     self._logger.exception("Failed to force-stop recorder")
             self.state_machine.transition(Event.ERROR)
@@ -222,6 +239,20 @@ class STTDaemon:
 
     def _transcribe_audio(self) -> None:
         """Transcribe audio (TRANSCRIBING → TYPING)."""
+        if self._live:
+            # Live mode: collect result from real-time streaming transcription
+            self._logger.info("Collecting streaming transcription result")
+            try:
+                self._transcribed_text = self.transcriber.stop_streaming()
+                self.state_machine.set_state(State.TYPING)
+                self.state_machine.transition(Event.TRANSCRIPTION_COMPLETE)
+            except Exception:
+                self._logger.exception("Streaming transcription failed")
+                notify_error("Transcription failed")
+                self.state_machine.transition(Event.ERROR)
+                self.state_machine.set_state(State.IDLE)
+            return
+
         if not self._audio_path:
             self._logger.error("No audio file to transcribe")
             notify_error("No audio file to transcribe")
@@ -321,6 +352,19 @@ class STTDaemon:
                     self._logger.info("Received shutdown signal")
                     self.state_machine.transition(Event.SHUTDOWN)
 
+                # Auto-stop recording if max duration exceeded
+                if (
+                    self._recording_start_time is not None
+                    and self.state_machine.state == State.RECORDING
+                    and time.monotonic() - self._recording_start_time >= self.config.max_recording_duration
+                ):
+                    self._logger.warning(
+                        "Max recording duration (%.0fs) reached, auto-stopping",
+                        self.config.max_recording_duration,
+                    )
+                    self.state_machine.transition(Event.TOGGLE_RECORDING)
+                    notify_recording_auto_stopped()
+
                 # Process state machine events
                 if not self.state_machine.process_events(handlers):
                     break
@@ -338,7 +382,10 @@ class STTDaemon:
         # Stop recording if in progress
         if self.recorder.is_recording():
             try:
-                self.recorder.stop_recording()
+                if self._live:
+                    self.recorder.stop_streaming()
+                else:
+                    self.recorder.stop_recording()
             except Exception:
                 self._logger.exception("Error stopping recorder")
 
@@ -371,11 +418,16 @@ def run(
 
     """
     # Setup logging
+    log_dir = Path.home() / ".local" / "share" / "stt-wayland"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    log_file = log_dir / "stt-daemon.log"
+
     logging.basicConfig(
         level=logging.INFO,
         format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
         handlers=[
             logging.StreamHandler(sys.stdout),
+            RotatingFileHandler(log_file, maxBytes=5 * 1024 * 1024, backupCount=3),
         ],
     )
 

--- a/src/stt_wayland/daemon.py
+++ b/src/stt_wayland/daemon.py
@@ -92,6 +92,18 @@ class STTDaemon:
         signal.signal(signal.SIGTERM, self._handle_shutdown_signal)
         signal.signal(signal.SIGINT, self._handle_shutdown_signal)
 
+    def _log_memory_usage(self) -> None:
+        """Log current resident memory usage."""
+        try:
+            with open("/proc/self/status") as f:  # noqa: PTH123
+                for line in f:
+                    if line.startswith("VmRSS:"):
+                        rss_kb = int(line.split()[1])
+                        self._logger.info("Memory usage: RSS=%dMB", rss_kb // 1024)
+                        return
+        except Exception:
+            self._logger.debug("Could not read memory usage")
+
     def _handle_toggle_signal(self, _signum: int, _frame: object) -> None:
         """Handle SIGUSR1 signal to toggle recording.
 
@@ -291,7 +303,13 @@ class STTDaemon:
 
         try:
             self._logger.info("Daemon ready, waiting for SIGUSR1 to toggle recording")
+            loop_count = 0
             while True:
+                loop_count += 1
+                if loop_count % 600 == 0:  # ~60 seconds (0.1s per iteration)
+                    self._log_memory_usage()
+                    loop_count = 0
+
                 # Process signal flags (async-safe pattern)
                 if self._toggle_requested:
                     self._toggle_requested = False
@@ -323,6 +341,12 @@ class STTDaemon:
                 self.recorder.stop_recording()
             except Exception:
                 self._logger.exception("Error stopping recorder")
+
+        # Release transcriber resources (connection pools, event loops)
+        try:
+            self.transcriber.close()
+        except Exception:
+            self._logger.exception("Error closing transcriber")
 
         self._remove_pid_file()
         self._logger.info("Daemon stopped")

--- a/src/stt_wayland/output/__init__.py
+++ b/src/stt_wayland/output/__init__.py
@@ -3,6 +3,7 @@
 from .clipboard import copy_to_clipboard
 from .notify import (
     notify_error,
+    notify_recording_auto_stopped,
     notify_recording_started,
     notify_recording_stopped,
     notify_transcription_complete,
@@ -14,6 +15,7 @@ __all__ = [
     "paste_text",
     "type_text",
     "notify_error",
+    "notify_recording_auto_stopped",
     "notify_recording_started",
     "notify_recording_stopped",
     "notify_transcription_complete",

--- a/src/stt_wayland/output/notify.py
+++ b/src/stt_wayland/output/notify.py
@@ -106,3 +106,13 @@ def notify_error(message: str) -> None:
         icon=ICON_ERROR,
         urgency=URGENCY_CRITICAL,
     )
+
+
+def notify_recording_auto_stopped() -> None:
+    """Show notification when recording is auto-stopped due to max duration."""
+    _send_notification(
+        summary="Recording Stopped",
+        body="Maximum recording duration reached",
+        icon=ICON_RECORDING,
+        urgency=URGENCY_NORMAL,
+    )

--- a/src/stt_wayland/transcription/gemini.py
+++ b/src/stt_wayland/transcription/gemini.py
@@ -14,6 +14,8 @@ if TYPE_CHECKING:
     from pathlib import Path
     from typing import Final
 
+    from stt_wayland.audio.recorder import AudioRecorder
+
 ERR_EMPTY_RESPONSE: Final[str] = "Empty transcription response"
 ERR_NO_SPEECH: Final[str] = "No speech detected in audio"
 TRANSCRIPTION_PROMPT: Final[str] = (
@@ -146,6 +148,34 @@ class GeminiTranscriber:
         Base implementation is a no-op. Subclasses may override to
         clean up additional resources.
         """
+
+    def start_streaming(self, recorder: AudioRecorder) -> None:
+        """Start real-time streaming transcription.
+
+        Only supported by Live API transcriber. Base implementation raises.
+
+        Args:
+            recorder: AudioRecorder instance in streaming mode.
+
+        Raises:
+            NotImplementedError: Always, unless overridden by subclass.
+
+        """
+        raise NotImplementedError
+
+    def stop_streaming(self) -> str:
+        """Stop streaming transcription and return the result.
+
+        Only supported by Live API transcriber. Base implementation raises.
+
+        Returns:
+            Transcribed text.
+
+        Raises:
+            NotImplementedError: Always, unless overridden by subclass.
+
+        """
+        raise NotImplementedError
 
     def _parse_instruction(self, text: str) -> tuple[str, str] | None:
         """Parse text for instruction keyword and split into content and instruction.

--- a/src/stt_wayland/transcription/gemini.py
+++ b/src/stt_wayland/transcription/gemini.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import gc
 import logging
 import re
 from typing import TYPE_CHECKING, NoReturn
@@ -139,6 +140,13 @@ class GeminiTranscriber:
         self._ask_keyword = ask_keyword
         self._logger = logging.getLogger(__name__)
 
+    def close(self) -> None:
+        """Close the transcriber and release resources.
+
+        Base implementation is a no-op. Subclasses may override to
+        clean up additional resources.
+        """
+
     def _parse_instruction(self, text: str) -> tuple[str, str] | None:
         """Parse text for instruction keyword and split into content and instruction.
 
@@ -265,8 +273,9 @@ class GeminiTranscriber:
         with audio_path.open("rb") as f:
             audio_data = f.read()
 
-        # Create audio part
+        # Create audio part and free raw bytes immediately
         audio_part = types.Part.from_bytes(data=audio_data, mime_type="audio/wav")
+        del audio_data
 
         # Select prompt based on refine/format settings
         if self._format_output:
@@ -349,3 +358,5 @@ class GeminiTranscriber:
             self._logger.exception("Transcription failed")
             msg = f"Transcription failed: {e}"
             raise RuntimeError(msg) from e
+        finally:
+            gc.collect()

--- a/src/stt_wayland/transcription/gemini_live.py
+++ b/src/stt_wayland/transcription/gemini_live.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import concurrent.futures
 import logging
 import threading
 import wave
@@ -21,6 +22,8 @@ from .gemini import (
 if TYPE_CHECKING:
     from pathlib import Path
     from typing import Final
+
+    from stt_wayland.audio.recorder import AudioRecorder
 
 # Audio chunk size for streaming (32KB)
 AUDIO_CHUNK_SIZE: Final[int] = 32768
@@ -130,6 +133,7 @@ class GeminiLiveTranscriber(GeminiTranscriber):
         self._loop_thread.start()
         self._closed = False
         self._client_closed = False
+        self._streaming_future: concurrent.futures.Future[str] | None = None
 
     def _raw_transcribe(self, audio_path: Path) -> str:
         """Transcribe audio using the Gemini Live API.
@@ -240,6 +244,152 @@ class GeminiLiveTranscriber(GeminiTranscriber):
                         break
 
             result = "".join(text_parts).strip()
+            if not result:
+                _raise_empty_response_error()
+
+        return result
+
+    def start_streaming(self, recorder: AudioRecorder) -> None:
+        """Start real-time streaming transcription.
+
+        Opens a Live API WebSocket session and begins consuming audio chunks
+        from the recorder in the background. Call stop_streaming() to finish
+        and retrieve the transcription result.
+
+        Args:
+            recorder: AudioRecorder instance (must already be in streaming mode).
+
+        Raises:
+            RuntimeError: If transcriber is closed or streaming already active.
+
+        """
+        if self._closed or self._client_closed:
+            msg = "Transcriber is closed"
+            raise RuntimeError(msg)
+
+        self._logger.info("Starting real-time streaming transcription with %s", self._model)
+        self._streaming_future = asyncio.run_coroutine_threadsafe(self._transcribe_stream_live(recorder), self._loop)
+
+    def stop_streaming(self) -> str:
+        """Stop streaming transcription and return the result.
+
+        Waits for the background transcription to complete (the recorder
+        must have been stopped first to signal end of stream).
+
+        Returns:
+            Transcribed text.
+
+        Raises:
+            RuntimeError: If transcription fails or times out.
+
+        """
+        if self._streaming_future is None:
+            msg = "No active streaming transcription"
+            raise RuntimeError(msg)
+
+        try:
+            result = self._streaming_future.result(timeout=LIVE_TRANSCRIBE_TIMEOUT)
+        except TimeoutError:
+            if not self._streaming_future.cancel():
+                self._logger.warning("Could not cancel timed-out streaming transcription")
+            msg = f"Streaming transcription timed out after {LIVE_TRANSCRIBE_TIMEOUT} seconds"
+            raise RuntimeError(msg) from None
+        finally:
+            self._streaming_future = None
+
+        return result
+
+    async def _transcribe_stream_live(self, recorder: AudioRecorder) -> str:
+        """Stream audio from recorder to Live API in real-time.
+
+        Sends audio and receives transcription concurrently. The Live API
+        emits transcription results while audio is still streaming, so both
+        must happen in parallel.
+
+        Args:
+            recorder: AudioRecorder instance to read chunks from.
+
+        Returns:
+            Transcribed text.
+
+        """
+        if self._format_output:
+            instruction = LIVE_TRANSCRIPTION_INSTRUCTION_FORMATTED
+        elif self._refine:
+            instruction = LIVE_TRANSCRIPTION_INSTRUCTION_REFINED
+        else:
+            instruction = LIVE_TRANSCRIPTION_INSTRUCTION
+
+        config = types.LiveConnectConfig(
+            response_modalities=[types.Modality.AUDIO],
+            input_audio_transcription=types.AudioTranscriptionConfig(),
+            system_instruction=types.Content(parts=[types.Part.from_text(text=instruction)]),
+        )
+
+        self._logger.info("Connecting to Live API for streaming transcription")
+        async with self._client.aio.live.connect(
+            model=self._model,
+            config=config,
+        ) as session:
+            self._logger.info("Live API session established")
+
+            # Collect transcription results concurrently while sending audio
+            text_parts: list[str] = []
+            chunks_sent = 0
+            bytes_sent = 0
+
+            async def _receive_transcription() -> None:
+                """Receive transcription results from the Live API."""
+                self._logger.info("Receive task started")
+                async for msg in session.receive():
+                    if msg.server_content:
+                        if msg.server_content.input_transcription and msg.server_content.input_transcription.text:
+                            self._logger.info(
+                                "Received transcription chunk: %s",
+                                msg.server_content.input_transcription.text[:80],
+                            )
+                            text_parts.append(msg.server_content.input_transcription.text)
+                        if msg.server_content.turn_complete:
+                            self._logger.info("Received turn_complete")
+                            break
+
+            # Start receiving in the background — the API sends results
+            # while audio is still streaming, so we must listen concurrently
+            receive_task = asyncio.create_task(_receive_transcription())
+
+            # Stream audio chunks as they arrive from the recorder
+            loop = asyncio.get_running_loop()
+            while True:
+                chunk = await loop.run_in_executor(None, recorder.read_chunk, 0.5)
+                if chunk is None:
+                    self._logger.info("End of audio stream (recorder stopped)")
+                    break
+                if chunk:  # Skip empty chunks (timeout with no data)
+                    await session.send_realtime_input(
+                        audio=types.Blob(data=chunk, mime_type="audio/pcm;rate=16000"),
+                    )
+                    chunks_sent += 1
+                    bytes_sent += len(chunk)
+
+            self._logger.info("Sent %d chunks (%d bytes) to Live API", chunks_sent, bytes_sent)
+
+            # Signal end of audio stream and wait for final transcription
+            await session.send_realtime_input(audio_stream_end=True)
+            self._logger.info("Sent audio_stream_end, waiting for transcription result")
+
+            # Wait for receive task with a timeout to avoid hanging forever
+            try:
+                await asyncio.wait_for(asyncio.shield(receive_task), timeout=30)
+            except TimeoutError:
+                self._logger.warning("Receive task timed out after 30s, cancelling")
+                receive_task.cancel()
+                try:
+                    await receive_task
+                except asyncio.CancelledError:
+                    pass
+
+            result = "".join(text_parts).strip()
+            self._logger.info("Streaming transcription result: %s", result[:100] if result else "(empty)")
             if not result:
                 _raise_empty_response_error()
 

--- a/src/stt_wayland/transcription/gemini_live.py
+++ b/src/stt_wayland/transcription/gemini_live.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import threading
 import wave
 from typing import TYPE_CHECKING
 
@@ -23,6 +24,9 @@ if TYPE_CHECKING:
 
 # Audio chunk size for streaming (32KB)
 AUDIO_CHUNK_SIZE: Final[int] = 32768
+
+# Timeout for live transcription (seconds)
+LIVE_TRANSCRIBE_TIMEOUT: Final[float] = 120
 
 # Live API transcription system instruction
 LIVE_TRANSCRIPTION_INSTRUCTION: Final[str] = (
@@ -106,11 +110,26 @@ class GeminiLiveTranscriber(GeminiTranscriber):
             )
             raise ValueError(msg)
 
-        self._live_client = genai.Client(
+        # Replace parent's client with one that uses v1beta API version.
+        # v1beta is required for Live API and is backward compatible
+        # with generate_content calls used for batch operations.
+        self._client = genai.Client(
             api_key=api_key,
             http_options=types.HttpOptions(api_version="v1beta"),
         )
         self._batch_model = batch_model
+
+        # Create a persistent event loop in a background daemon thread
+        # to avoid creating/destroying loops on every transcription call.
+        self._loop = asyncio.new_event_loop()
+        self._loop_thread = threading.Thread(
+            target=self._loop.run_forever,
+            name="gemini-live-event-loop",
+            daemon=True,
+        )
+        self._loop_thread.start()
+        self._closed = False
+        self._client_closed = False
 
     def _raw_transcribe(self, audio_path: Path) -> str:
         """Transcribe audio using the Gemini Live API.
@@ -125,17 +144,27 @@ class GeminiLiveTranscriber(GeminiTranscriber):
             Raw transcribed text from the API.
 
         Raises:
-            RuntimeError: If the API returns an empty response.
+            RuntimeError: If the API returns an empty response or transcriber is closed.
             ValueError: If the audio file is not a valid WAV file.
 
         """
+        if self._closed or self._client_closed:
+            msg = "Transcriber is closed"
+            raise RuntimeError(msg)
+
         # Read WAV file and strip header to get raw PCM
         pcm_data = self._extract_pcm_from_wav(audio_path)
         self._logger.info("Extracted %d bytes of PCM data from %s", len(pcm_data), audio_path)
 
-        # Note: asyncio.run() requires no event loop to be running.
-        # This is safe as the daemon's main loop is synchronous.
-        return asyncio.run(self._transcribe_live(pcm_data))
+        # Submit to the persistent event loop thread
+        future = asyncio.run_coroutine_threadsafe(self._transcribe_live(pcm_data), self._loop)
+        try:
+            return future.result(timeout=LIVE_TRANSCRIBE_TIMEOUT)
+        except TimeoutError:
+            if not future.cancel():
+                self._logger.warning("Could not cancel timed-out live transcription task")
+            msg = f"Live transcription timed out after {LIVE_TRANSCRIBE_TIMEOUT} seconds"
+            raise RuntimeError(msg) from None
 
     @staticmethod
     def _extract_pcm_from_wav(audio_path: Path) -> bytes:
@@ -185,7 +214,7 @@ class GeminiLiveTranscriber(GeminiTranscriber):
             system_instruction=types.Content(parts=[types.Part.from_text(text=instruction)]),
         )
 
-        async with self._live_client.aio.live.connect(
+        async with self._client.aio.live.connect(
             model=self._model,
             config=config,
         ) as session:
@@ -214,7 +243,38 @@ class GeminiLiveTranscriber(GeminiTranscriber):
             if not result:
                 _raise_empty_response_error()
 
-            return result
+        return result
+
+    def close(self) -> None:
+        """Close the transcriber and release resources.
+
+        Closes the genai client, stops the persistent event loop, and joins
+        the background thread. Safe to call multiple times.
+        """
+        if self._closed:
+            return
+
+        # Close the genai client (sync + async sides) — only once
+        if not self._client_closed:
+            try:
+                if self._loop.is_running():
+                    future = asyncio.run_coroutine_threadsafe(self._client.aio.aclose(), self._loop)
+                    future.result(timeout=5)
+                self._client.close()
+                self._client_closed = True
+            except Exception:
+                self._logger.exception("Error closing genai client")
+
+        if self._loop.is_running():
+            self._loop.call_soon_threadsafe(self._loop.stop)
+        self._loop_thread.join(timeout=5)
+        if self._loop_thread.is_alive():
+            self._logger.warning("Event loop thread did not stop in time; close() can be retried")
+        else:
+            if not self._loop.is_closed():
+                self._loop.close()
+            self._closed = True
+            self._logger.info("Gemini Live transcriber closed")
 
     def _apply_instruction(self, content: str, instruction: str) -> str:
         """Apply an instruction using the batch model (REST API).

--- a/tests/test_gemini_live.py
+++ b/tests/test_gemini_live.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import struct
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -98,22 +99,24 @@ def _make_client_factory() -> tuple[MagicMock, MagicMock, MagicMock]:
 
     The factory uses side_effect to distinguish between:
     - Parent client call: genai.Client(api_key=...) -- no http_options
-    - Live client call: genai.Client(api_key=..., http_options=...) -- with http_options
+    - Live (v1beta) client call: genai.Client(api_key=..., http_options=...) -- with http_options
+
+    After __init__, self._client is the v1beta client (the second call overrides the first).
 
     Returns:
-        A tuple of (mock_class, mock_parent_client, mock_live_client).
+        A tuple of (mock_class, mock_parent_client, mock_v1beta_client).
 
     """
     mock_parent_client = MagicMock(name="parent_client")
-    mock_live_client = MagicMock(name="live_client")
+    mock_v1beta_client = MagicMock(name="v1beta_client")
 
     def _factory(**kwargs: object) -> MagicMock:
         if "http_options" in kwargs:
-            return mock_live_client
+            return mock_v1beta_client
         return mock_parent_client
 
     mock_class = MagicMock(side_effect=_factory)
-    return mock_class, mock_parent_client, mock_live_client
+    return mock_class, mock_parent_client, mock_v1beta_client
 
 
 class TestGeminiLiveTranscriberInit:
@@ -163,27 +166,27 @@ class TestGeminiLiveTranscriberInit:
 
     @patch(_GENAI_CLIENT_PATCH)
     def test_init_creates_two_clients(self, mock_class: MagicMock) -> None:
-        """Test that genai.Client is called twice: once for parent, once for live."""
+        """Test that genai.Client is called twice: once for parent, once to override with v1beta."""
         GeminiLiveTranscriber(api_key="test-key")
 
         assert mock_class.call_count == 2
         # First call: parent client (no http_options)
         parent_call = mock_class.call_args_list[0]
         assert parent_call == ((), {"api_key": "test-key"})
-        # Second call: live client (with http_options for v1beta)
-        live_call = mock_class.call_args_list[1]
-        assert live_call.kwargs["api_key"] == "test-key"
-        assert live_call.kwargs["http_options"].api_version == "v1beta"
+        # Second call: v1beta client that replaces parent's _client
+        v1beta_call = mock_class.call_args_list[1]
+        assert v1beta_call.kwargs["api_key"] == "test-key"
+        assert v1beta_call.kwargs["http_options"].api_version == "v1beta"
 
     @patch(_GENAI_CLIENT_PATCH)
-    def test_init_live_client_uses_v1beta(self, mock_class: MagicMock) -> None:
-        """Test that the live client is created with api_version='v1beta'."""
-        mock_class_obj, _mock_parent, mock_live = _make_client_factory()
+    def test_init_client_uses_v1beta(self, mock_class: MagicMock) -> None:
+        """Test that self._client is the v1beta client (overrides parent's)."""
+        mock_class_obj, _mock_parent, mock_v1beta = _make_client_factory()
         mock_class.side_effect = mock_class_obj.side_effect
 
         transcriber = GeminiLiveTranscriber(api_key="test-key")
 
-        assert transcriber._live_client is mock_live
+        assert transcriber._client is mock_v1beta
 
     @patch(_GENAI_CLIENT_PATCH)
     def test_is_subclass_of_gemini_transcriber(self, _mock_class: MagicMock) -> None:
@@ -766,7 +769,7 @@ class TestLiveTranscriberIntegration:
     @patch(_GENAI_CLIENT_PATCH)
     def test_transcribe_delegates_to_raw_transcribe(self, mock_class: MagicMock, tmp_path: Path) -> None:
         """Test that parent's transcribe() calls the overridden _raw_transcribe."""
-        mock_class_obj, mock_parent, mock_live = _make_client_factory()
+        mock_class_obj, _mock_parent, mock_live = _make_client_factory()
         mock_class.side_effect = mock_class_obj.side_effect
 
         mock_session = MagicMock()
@@ -792,9 +795,9 @@ class TestLiveTranscriberIntegration:
         result = transcriber.transcribe(wav_file)
 
         assert result == "Hello world"
-        # Verify it used live_client.aio.live.connect, NOT parent's models.generate_content
+        # Verify it used _client.aio.live.connect (v1beta), NOT generate_content
         mock_live.aio.live.connect.assert_called_once()
-        mock_parent.models.generate_content.assert_not_called()
+        mock_live.models.generate_content.assert_not_called()
 
     @patch(_GENAI_CLIENT_PATCH)
     def test_transcribe_no_speech_raises(self, mock_class: MagicMock, tmp_path: Path) -> None:
@@ -828,7 +831,7 @@ class TestLiveTranscriberIntegration:
     @patch(_GENAI_CLIENT_PATCH)
     def test_transcribe_with_ask_keyword(self, mock_class: MagicMock, tmp_path: Path) -> None:
         """Test that ask keyword works through parent's transcribe() with live backend."""
-        mock_class_obj, mock_parent, mock_live = _make_client_factory()
+        mock_class_obj, _mock_parent, mock_live = _make_client_factory()
         mock_class.side_effect = mock_class_obj.side_effect
 
         # Live API returns text starting with ask keyword
@@ -847,10 +850,10 @@ class TestLiveTranscriberIntegration:
         mock_connect.__aenter__.return_value = mock_session
         mock_live.aio.live.connect.return_value = mock_connect
 
-        # Mock the generate_content for the ask query answer (uses parent client)
+        # Mock the generate_content for the ask query answer (uses self._client, the v1beta one)
         ai_answer_response = MagicMock()
         ai_answer_response.text = "Python is a programming language"
-        mock_parent.models.generate_content.return_value = ai_answer_response
+        mock_live.models.generate_content.return_value = ai_answer_response
 
         transcriber = GeminiLiveTranscriber(api_key="test-key", ask_keyword="hey")
 
@@ -864,7 +867,7 @@ class TestLiveTranscriberIntegration:
     @patch(_GENAI_CLIENT_PATCH)
     def test_apply_instruction_uses_batch_model(self, mock_class: MagicMock, tmp_path: Path) -> None:
         """Test that _apply_instruction uses _batch_model, not _model."""
-        mock_class_obj, mock_parent, mock_live = _make_client_factory()
+        mock_class_obj, _mock_parent, mock_live = _make_client_factory()
         mock_class.side_effect = mock_class_obj.side_effect
 
         # Live API returns text with instruction keyword
@@ -883,10 +886,10 @@ class TestLiveTranscriberIntegration:
         mock_connect.__aenter__.return_value = mock_session
         mock_live.aio.live.connect.return_value = mock_connect
 
-        # Mock the generate_content for the instruction processing (uses parent client)
+        # Mock the generate_content for the instruction processing (uses self._client, v1beta)
         instruction_response = MagicMock()
         instruction_response.text = "du contenu"
-        mock_parent.models.generate_content.return_value = instruction_response
+        mock_live.models.generate_content.return_value = instruction_response
 
         transcriber = GeminiLiveTranscriber(
             api_key="test-key",
@@ -901,13 +904,13 @@ class TestLiveTranscriberIntegration:
 
         assert result == "du contenu"
         # Verify generate_content was called with batch_model, NOT the live model
-        call_args = mock_parent.models.generate_content.call_args
+        call_args = mock_live.models.generate_content.call_args
         assert call_args.kwargs["model"] == "gemini-2.5-flash"
 
     @patch(_GENAI_CLIENT_PATCH)
     def test_answer_query_uses_batch_model(self, mock_class: MagicMock, tmp_path: Path) -> None:
         """Test that _answer_query uses _batch_model, not _model."""
-        mock_class_obj, mock_parent, mock_live = _make_client_factory()
+        mock_class_obj, _mock_parent, mock_live = _make_client_factory()
         mock_class.side_effect = mock_class_obj.side_effect
 
         # Live API returns text starting with ask keyword
@@ -926,10 +929,10 @@ class TestLiveTranscriberIntegration:
         mock_connect.__aenter__.return_value = mock_session
         mock_live.aio.live.connect.return_value = mock_connect
 
-        # Mock the generate_content for the ask query answer (uses parent client)
+        # Mock the generate_content for the ask query answer (uses self._client, v1beta)
         ai_answer_response = MagicMock()
         ai_answer_response.text = "Paris"
-        mock_parent.models.generate_content.return_value = ai_answer_response
+        mock_live.models.generate_content.return_value = ai_answer_response
 
         transcriber = GeminiLiveTranscriber(
             api_key="test-key",
@@ -944,7 +947,7 @@ class TestLiveTranscriberIntegration:
 
         assert result == "Paris"
         # Verify generate_content was called with batch_model, NOT the live model
-        call_args = mock_parent.models.generate_content.call_args
+        call_args = mock_live.models.generate_content.call_args
         assert call_args.kwargs["model"] == "gemini-2.5-flash"
 
 
@@ -966,17 +969,17 @@ class TestNoLiveLangParameter:
     @patch(_GENAI_CLIENT_PATCH)
     def test_live_apply_instruction_no_lang_directive(self, mock_class: MagicMock) -> None:
         """Test that live _apply_instruction does not append language directive."""
-        mock_class_obj, mock_parent, _mock_live = _make_client_factory()
+        mock_class_obj, _mock_parent, mock_v1beta = _make_client_factory()
         mock_class.side_effect = mock_class_obj.side_effect
 
         mock_response = MagicMock()
         mock_response.text = "Result"
-        mock_parent.models.generate_content.return_value = mock_response
+        mock_v1beta.models.generate_content.return_value = mock_response
 
         transcriber = GeminiLiveTranscriber(api_key="test-key")
         transcriber._apply_instruction("content", "instruction")
 
-        call_args = mock_parent.models.generate_content.call_args
+        call_args = mock_v1beta.models.generate_content.call_args
         contents = call_args.kwargs["contents"]
         prompt_text = contents[0].text
         assert "CRITICAL LANGUAGE REQUIREMENT" not in prompt_text
@@ -984,17 +987,91 @@ class TestNoLiveLangParameter:
     @patch(_GENAI_CLIENT_PATCH)
     def test_live_answer_query_no_lang_directive(self, mock_class: MagicMock) -> None:
         """Test that live _answer_query does not append language directive."""
-        mock_class_obj, mock_parent, _mock_live = _make_client_factory()
+        mock_class_obj, _mock_parent, mock_v1beta = _make_client_factory()
         mock_class.side_effect = mock_class_obj.side_effect
 
         mock_response = MagicMock()
         mock_response.text = "Answer"
-        mock_parent.models.generate_content.return_value = mock_response
+        mock_v1beta.models.generate_content.return_value = mock_response
 
         transcriber = GeminiLiveTranscriber(api_key="test-key", ask_keyword="hey")
         transcriber._answer_query("what is Python")
 
-        call_args = mock_parent.models.generate_content.call_args
+        call_args = mock_v1beta.models.generate_content.call_args
         contents = call_args.kwargs["contents"]
         prompt_text = contents[0].text
         assert "CRITICAL LANGUAGE REQUIREMENT" not in prompt_text
+
+
+class TestGeminiLiveTranscriberClose:
+    """Tests for GeminiLiveTranscriber.close() lifecycle."""
+
+    @patch(_GENAI_CLIENT_PATCH)
+    def test_close_stops_event_loop(self, _mock_class: MagicMock) -> None:
+        """Test that close() stops the persistent event loop."""
+        transcriber = GeminiLiveTranscriber(api_key="test-key")
+
+        assert transcriber._loop.is_running()
+        assert transcriber._loop_thread.is_alive()
+
+        transcriber.close()
+
+        assert not transcriber._loop.is_running()
+        assert not transcriber._loop_thread.is_alive()
+        assert transcriber._loop.is_closed()
+
+    @patch(_GENAI_CLIENT_PATCH)
+    def test_close_is_idempotent(self, _mock_class: MagicMock) -> None:
+        """Test that calling close() multiple times is safe."""
+        transcriber = GeminiLiveTranscriber(api_key="test-key")
+
+        transcriber.close()
+        # Second close should not raise
+        transcriber.close()
+
+        assert transcriber._closed
+
+    @patch(_GENAI_CLIENT_PATCH)
+    def test_close_sets_closed_flag(self, _mock_class: MagicMock) -> None:
+        """Test that close() sets the _closed flag."""
+        transcriber = GeminiLiveTranscriber(api_key="test-key")
+
+        assert not transcriber._closed
+        transcriber.close()
+        assert transcriber._closed
+
+    @patch(_GENAI_CLIENT_PATCH)
+    def test_raw_transcribe_after_close_raises(self, _mock_class: MagicMock) -> None:
+        """Test that _raw_transcribe raises RuntimeError after close()."""
+        transcriber = GeminiLiveTranscriber(api_key="test-key")
+        transcriber.close()
+
+        with pytest.raises(RuntimeError, match="Transcriber is closed"):
+            transcriber._raw_transcribe(Path("/tmp/dummy.wav"))
+
+
+class TestGeminiLiveTranscriberTimeout:
+    """Tests for timeout and cancellation behavior."""
+
+    @patch("stt_wayland.transcription.gemini_live.LIVE_TRANSCRIBE_TIMEOUT", 0.1)
+    @patch(_GENAI_CLIENT_PATCH)
+    def test_timeout_cancels_future(self, _mock_class: MagicMock, tmp_path: Path) -> None:
+        """Test that a timeout on future.result cancels the task and raises RuntimeError."""
+        transcriber = GeminiLiveTranscriber(api_key="test-key")
+
+        # Create a valid WAV file
+        wav_file = tmp_path / "test.wav"
+        _make_wav_file(wav_file)
+
+        # Replace _transcribe_live with a coroutine that hangs
+        async def hang_forever(_pcm_data: bytes) -> str:
+            await asyncio.sleep(3600)
+            return "never reached"
+
+        transcriber._transcribe_live = hang_forever  # type: ignore[assignment]
+
+        # Call the real _raw_transcribe (patched timeout to 0.1s)
+        with pytest.raises(RuntimeError, match="timed out"):
+            transcriber.transcribe(wav_file)
+
+        transcriber.close()

--- a/tests/test_live_flag.py
+++ b/tests/test_live_flag.py
@@ -109,9 +109,12 @@ class TestDaemonRunLiveParameter:
 class TestSTTDaemonLiveTranscriber:
     """Test that STTDaemon uses GeminiLiveTranscriber when live=True."""
 
+    @patch("stt_wayland.daemon.AudioRecorder")
     @patch("stt_wayland.daemon.GeminiLiveTranscriber")
     @patch("stt_wayland.daemon.GeminiTranscriber")
-    def test_live_false_uses_gemini_transcriber(self, mock_gemini: MagicMock, _mock_live: MagicMock) -> None:
+    def test_live_false_uses_gemini_transcriber(
+        self, mock_gemini: MagicMock, _mock_live: MagicMock, _mock_recorder: MagicMock
+    ) -> None:
         """Test that live=False uses GeminiTranscriber."""
         config = MagicMock()
         config.api_key = "test-key"
@@ -122,9 +125,12 @@ class TestSTTDaemonLiveTranscriber:
         mock_gemini.assert_called_once()
         _mock_live.assert_not_called()
 
+    @patch("stt_wayland.daemon.AudioRecorder")
     @patch("stt_wayland.daemon.GeminiLiveTranscriber")
     @patch("stt_wayland.daemon.GeminiTranscriber")
-    def test_live_true_uses_gemini_live_transcriber(self, _mock_gemini: MagicMock, mock_live: MagicMock) -> None:
+    def test_live_true_uses_gemini_live_transcriber(
+        self, _mock_gemini: MagicMock, mock_live: MagicMock, _mock_recorder: MagicMock
+    ) -> None:
         """Test that live=True uses GeminiLiveTranscriber."""
         config = MagicMock()
         config.api_key = "test-key"
@@ -135,9 +141,12 @@ class TestSTTDaemonLiveTranscriber:
         mock_live.assert_called_once()
         _mock_gemini.assert_not_called()
 
+    @patch("stt_wayland.daemon.AudioRecorder")
     @patch("stt_wayland.daemon.GeminiLiveTranscriber")
     @patch("stt_wayland.daemon.GeminiTranscriber")
-    def test_live_true_always_passes_config_model(self, _mock_gemini: MagicMock, mock_live: MagicMock) -> None:
+    def test_live_true_always_passes_config_model(
+        self, _mock_gemini: MagicMock, mock_live: MagicMock, _mock_recorder: MagicMock
+    ) -> None:
         """Test that live=True always passes config.model directly to GeminiLiveTranscriber."""
         config = MagicMock()
         config.api_key = "test-key"
@@ -149,9 +158,12 @@ class TestSTTDaemonLiveTranscriber:
         call_kwargs = mock_live.call_args[1] if mock_live.call_args[1] else {}
         assert call_kwargs.get("model") == "gemini-3.1-flash-live-preview"
 
+    @patch("stt_wayland.daemon.AudioRecorder")
     @patch("stt_wayland.daemon.GeminiLiveTranscriber")
     @patch("stt_wayland.daemon.GeminiTranscriber")
-    def test_live_true_passes_all_options(self, _mock_gemini: MagicMock, mock_live: MagicMock) -> None:
+    def test_live_true_passes_all_options(
+        self, _mock_gemini: MagicMock, mock_live: MagicMock, _mock_recorder: MagicMock
+    ) -> None:
         """Test that live=True passes refine, format_output, instruction_keyword, ask_keyword."""
         config = MagicMock()
         config.api_key = "test-key"
@@ -173,9 +185,12 @@ class TestSTTDaemonLiveTranscriber:
         assert call_kwargs.get("instruction_keyword") == "boom"
         assert call_kwargs.get("ask_keyword") == "hey"
 
+    @patch("stt_wayland.daemon.AudioRecorder")
     @patch("stt_wayland.daemon.GeminiLiveTranscriber")
     @patch("stt_wayland.daemon.GeminiTranscriber")
-    def test_live_true_passes_batch_model_from_config(self, _mock_gemini: MagicMock, mock_live: MagicMock) -> None:
+    def test_live_true_passes_batch_model_from_config(
+        self, _mock_gemini: MagicMock, mock_live: MagicMock, _mock_recorder: MagicMock
+    ) -> None:
         """Test that live=True passes config.model as batch_model for REST API calls."""
         config = MagicMock()
         config.api_key = "test-key"
@@ -187,9 +202,12 @@ class TestSTTDaemonLiveTranscriber:
         call_kwargs = mock_live.call_args[1] if mock_live.call_args[1] else {}
         assert call_kwargs.get("batch_model") == "gemini-2.5-flash"
 
+    @patch("stt_wayland.daemon.AudioRecorder")
     @patch("stt_wayland.daemon.GeminiLiveTranscriber")
     @patch("stt_wayland.daemon.GeminiTranscriber")
-    def test_live_false_passes_all_options(self, mock_gemini: MagicMock, _mock_live: MagicMock) -> None:
+    def test_live_false_passes_all_options(
+        self, mock_gemini: MagicMock, _mock_live: MagicMock, _mock_recorder: MagicMock
+    ) -> None:
         """Test that live=False passes refine, format_output, instruction_keyword, ask_keyword to GeminiTranscriber."""
         config = MagicMock()
         config.api_key = "test-key"
@@ -225,10 +243,11 @@ class TestNoLangParameterPassthrough:
         _, kwargs = mock_run.call_args
         assert "lang" not in kwargs
 
+    @patch("stt_wayland.daemon.AudioRecorder")
     @patch("stt_wayland.daemon.GeminiLiveTranscriber")
     @patch("stt_wayland.daemon.GeminiTranscriber")
     def test_daemon_does_not_pass_lang_to_gemini_transcriber(
-        self, mock_gemini: MagicMock, _mock_live: MagicMock
+        self, mock_gemini: MagicMock, _mock_live: MagicMock, _mock_recorder: MagicMock
     ) -> None:
         """Test that STTDaemon does not pass lang to GeminiTranscriber."""
         config = MagicMock()
@@ -241,10 +260,11 @@ class TestNoLangParameterPassthrough:
         call_kwargs = mock_gemini.call_args[1] if mock_gemini.call_args[1] else {}
         assert "lang" not in call_kwargs
 
+    @patch("stt_wayland.daemon.AudioRecorder")
     @patch("stt_wayland.daemon.GeminiLiveTranscriber")
     @patch("stt_wayland.daemon.GeminiTranscriber")
     def test_daemon_does_not_pass_lang_to_gemini_live_transcriber(
-        self, _mock_gemini: MagicMock, mock_live: MagicMock
+        self, _mock_gemini: MagicMock, mock_live: MagicMock, _mock_recorder: MagicMock
     ) -> None:
         """Test that STTDaemon does not pass lang to GeminiLiveTranscriber when live=True."""
         config = MagicMock()

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,10 @@
 version = 1
 revision = 3
 requires-python = ">=3.14"
+resolution-markers = [
+    "python_full_version >= '3.15'",
+    "python_full_version < '3.15'",
+]
 
 [[package]]
 name = "annotated-types"
@@ -21,6 +25,44 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/16/ce/8a777047513153587e5434fd752e89334ac33e379aa3497db860eeb60377/anyio-4.12.0.tar.gz", hash = "sha256:73c693b567b0c55130c104d0b43a9baf3aa6a31fc6110116509f27bf75e21ec0", size = 228266, upload-time = "2025-11-28T23:37:38.911Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7f/9c/36c5c37947ebfb8c7f22e0eb6e4d188ee2d53aa3880f3f2744fb894f0cb1/anyio-4.12.0-py3-none-any.whl", hash = "sha256:dad2376a628f98eeca4881fc56cd06affd18f659b17a747d3ff0307ced94b1bb", size = 113362, upload-time = "2025-11-28T23:36:57.897Z" },
+]
+
+[[package]]
+name = "ast-serialize"
+version = "0.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a9/9d/912fefab0e30aee6a3af8a62bbea4a81b29afa4ba2c973d31170620a26de/ast_serialize-0.3.0.tar.gz", hash = "sha256:1bc3ca09a63a021376527c4e938deedd11d11d675ce850e6f9c7487f5889992b", size = 60689, upload-time = "2026-04-30T23:24:48.104Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6f/57/a54d4de491d6cdd7a4e4b0952cc3ca9f60dcefa7b5fb48d6d492debe1649/ast_serialize-0.3.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:3a867927df59f76a18dc1d874a0b2c079b42c58972dca637905576deb0912e14", size = 1182966, upload-time = "2026-04-30T23:23:57.376Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/9e/a5db014bb0f91b209236b57c429389e31290c0093532b8436d577699b2fa/ast_serialize-0.3.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a6fb063bf040abf8321e7b8113a0554eda445ffc508aa51287f8808886a5ae22", size = 1171316, upload-time = "2026-04-30T23:23:59.63Z" },
+    { url = "https://files.pythonhosted.org/packages/15/59/fd55133e478c4326f60a11df02573bf7ccb2ac685810b50f1803d0f68053/ast_serialize-0.3.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5075cd8482573d743586779e5f9b652a015e37d4e95132d7e5a9bc5c8f483d8f", size = 1232234, upload-time = "2026-04-30T23:24:01.168Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/79/0ca1d26357ecb4a697d74d00b73ef3137f24c140424125393a0de820eb09/ast_serialize-0.3.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:41560b27794f4553b0f77811e9fb325b77db4a2b39018d437e09932275306e66", size = 1233437, upload-time = "2026-04-30T23:24:03.151Z" },
+    { url = "https://files.pythonhosted.org/packages/53/3e/7078ec94dd6e124b8e028ac77016a4f13c83fa1c145790f2e68f3816998b/ast_serialize-0.3.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b967c01ca74909c5d90e0fe4393401e2cc5da5ebd9a6262a19e45ffd3757dec8", size = 1440188, upload-time = "2026-04-30T23:24:04.717Z" },
+    { url = "https://files.pythonhosted.org/packages/21/16/cca7195ef55a012f8013c3442afa91d287a0a36dcf88b480b262475135b3/ast_serialize-0.3.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:424ebb8f46cd993f7cec4009d119312d8433dd90e6b0df0499cd2c91bdcc5af9", size = 1254211, upload-time = "2026-04-30T23:24:06.18Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/0f/f3d4dfae67dee6580534361a6343367d34217e7d25cff858bd1d8f03b8ed/ast_serialize-0.3.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d14b1d566b56e2ee70b11fec1de7e0b94ec7cd83717ec7d189967841a361190e", size = 1255973, upload-time = "2026-04-30T23:24:07.772Z" },
+    { url = "https://files.pythonhosted.org/packages/14/41/55fbfe02c42f40fbe3e74eda167d977d555ff720ce1abfa08515236efd88/ast_serialize-0.3.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7ba30b18735f047ec11103d1ab92f4789cf1fea1e0dc89b04a2f5a0632fd79de", size = 1298629, upload-time = "2026-04-30T23:24:09.4Z" },
+    { url = "https://files.pythonhosted.org/packages/28/36/7d2501cacc7989fb8504aa9da2a2022a174200a59d4e6639de4367a57fdd/ast_serialize-0.3.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e6ea0754cb7b0f682ebb005ffb0d18f8d17993490d9c289863cd69cacc4ab8df", size = 1408435, upload-time = "2026-04-30T23:24:11.013Z" },
+    { url = "https://files.pythonhosted.org/packages/03/e7/54e3b469c3fa0bf9cd532fa643d1d33b73303f8d70beac3e366b68dd64b7/ast_serialize-0.3.0-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:a0c5aa1073a5ba7b2abaa4b54abe8b8d75c4d1e2d54a2ff70b0ca6222fea5728", size = 1508174, upload-time = "2026-04-30T23:24:12.635Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/2a/9b9621865b02c60539e26d9b114a312b4fa46aa703e33e79317174bfea21/ast_serialize-0.3.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:4e52650d834c1ea7791969a361de2c54c13b2fb4c519ec79445fa8b9021a147d", size = 1502354, upload-time = "2026-04-30T23:24:14.186Z" },
+    { url = "https://files.pythonhosted.org/packages/34/dd/f138bc5c43b0c414fdd12eefe15677839323078b6e75301ad7f96cd26d45/ast_serialize-0.3.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:15bd6af3f136c61dae27805eb6b8f3269e85a545c4c27ffe9e530ead78d2b36d", size = 1450504, upload-time = "2026-04-30T23:24:16.076Z" },
+    { url = "https://files.pythonhosted.org/packages/68/cf/97ef9e1c315601db74365955c8edd3292e3055500d6317602815dbdf08ae/ast_serialize-0.3.0-cp314-cp314t-win32.whl", hash = "sha256:d188bfe37b674b49708497683051d4b571366a668799c9b8e8a94513694969d9", size = 1058662, upload-time = "2026-04-30T23:24:17.535Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/d6/e2c3483c31580fdb623f92ad38d2f856cde4b9205a3e6bd84760f3de7d82/ast_serialize-0.3.0-cp314-cp314t-win_amd64.whl", hash = "sha256:5832c2fdf8f8a6cf682b4cfcf677f5eaf39b4ddbc490f5480cfccdd1e7ce8fa1", size = 1100349, upload-time = "2026-04-30T23:24:18.992Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/89/29abcb1fe18a429cda60c6e0bbd1d6e90499339842a2f548d7567542357e/ast_serialize-0.3.0-cp314-cp314t-win_arm64.whl", hash = "sha256:670f177188d128fb7f9f15b5ad0e1b553d22c34e3f584dcb83eb8077600437f0", size = 1072895, upload-time = "2026-04-30T23:24:20.706Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/93/72abad83966ed6235647c9f956417dc1e17e997696388521910e3d1fa3f4/ast_serialize-0.3.0-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:2ec2fafa5e4313cc8feed96e436ebe19ac7bc6fa41fbc2827e826c48b9e4c3a9", size = 1190024, upload-time = "2026-04-30T23:24:22.486Z" },
+    { url = "https://files.pythonhosted.org/packages/85/4f/eb88584b2f0234e581762011208ca203252bf6c98e59b4769daa571f3576/ast_serialize-0.3.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ef6d3c08b7b4cd29b48410338e134764a00e76d25841eb02c1084e868c888ecc", size = 1178633, upload-time = "2026-04-30T23:24:24.35Z" },
+    { url = "https://files.pythonhosted.org/packages/56/51/cf1ec1ff3e616373d0dcbd5fad502e0029dc541f13ab642259762a7d127f/ast_serialize-0.3.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3d841424f41b886e98044abc80769c14a956e6e5ccd5fb5b0d9f5ead72be18a4", size = 1241351, upload-time = "2026-04-30T23:24:25.987Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/44/68fcf50478cf1093f2d423f034ae06453122c8b415d8e21a44668eca485d/ast_serialize-0.3.0-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d21453734ad39367ede5d37efe4f59f830ce1c09f432fc72a90e368f77a4a3e7", size = 1239582, upload-time = "2026-04-30T23:24:27.808Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/c1/a6c9fa284eceb5fc6f21347e968445a051d7ca2c4d34e6a04314646dbcee/ast_serialize-0.3.0-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f5e110cdce2a347e1dd987529c88ef54d26f67848dce3eba1b3b2cc2cf085c94", size = 1448853, upload-time = "2026-04-30T23:24:29.534Z" },
+    { url = "https://files.pythonhosted.org/packages/23/5f/8ad3829a09e4e8c5328a53ce7d4711d660944e3e164c5f6abcc2c8f27167/ast_serialize-0.3.0-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3b6e23a98e57560a055f5c4b68700a0fd5ce483d2814c23140b3638c7f5d1e61", size = 1262204, upload-time = "2026-04-30T23:24:31.482Z" },
+    { url = "https://files.pythonhosted.org/packages/25/13/44aa28d97f10e25247e8576b5f6b2795d4fa1a80acc88acc942c508d06f7/ast_serialize-0.3.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c1c9e763d70293d65ce1e1ea8c943140c68d0953f0268c7ee0998f2e07f77dd0", size = 1266458, upload-time = "2026-04-30T23:24:33.088Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/58/b3a8be3777cd3744324fd5cec0d80d37cd96fc7cbb0fb010e03dff1e870f/ast_serialize-0.3.0-cp39-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4388a1796c228f1ce5c391426f7d21a0003ad3b47f677dbeded9bd1a85c7209f", size = 1308700, upload-time = "2026-04-30T23:24:34.657Z" },
+    { url = "https://files.pythonhosted.org/packages/13/03/f8312d6b57f5471a9dc7946f22b8798a1fc296d38c25766223aacadec42c/ast_serialize-0.3.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:5283cdcc0c64c3d8b9b688dc6aaa012d9c0cf1380a7f774a6bae6a1c01b3205a", size = 1416724, upload-time = "2026-04-30T23:24:36.562Z" },
+    { url = "https://files.pythonhosted.org/packages/50/5d/13fc3789a7abac00559da2e2e9f386db4612aa1f84fc53d09bf714c37545/ast_serialize-0.3.0-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:f5ef88cc5842a5d7a6ac09dc0d5fc2c98f5d276c1f076f866d55047ce886785b", size = 1515441, upload-time = "2026-04-30T23:24:38.018Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/b9/7ab43fc7a23b1f970281093228f5f79bed6edeed7a3e672bde6d7a832a58/ast_serialize-0.3.0-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:cc14bf402bdc0978594ecce783793de2c7470cd4f5cd7eb286ca97ed8ff7cba9", size = 1510522, upload-time = "2026-04-30T23:24:39.798Z" },
+    { url = "https://files.pythonhosted.org/packages/56/ec/d75fc2b788d319f1fad77c14156896f31afdfc68af85b505e5bdebcb9592/ast_serialize-0.3.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:11eae0cf1b7b3e0678133cc2daa974ea972caf02eb4b3aa062af6fa9acd52c57", size = 1460917, upload-time = "2026-04-30T23:24:41.305Z" },
+    { url = "https://files.pythonhosted.org/packages/95/74/f99c81193a2725911e1911ae567ed27c2f2419332c7f3537366f9d238cac/ast_serialize-0.3.0-cp39-abi3-win32.whl", hash = "sha256:2db3dd99de5e6a5a11d7dda73de8750eb6e5baaf25245adf7bdcfe64b6108ae2", size = 1067804, upload-time = "2026-04-30T23:24:43.091Z" },
+    { url = "https://files.pythonhosted.org/packages/16/81/76af00c47daa151e89f98ae21fbbcb2840aaa9f5766579c4da76a3c57188/ast_serialize-0.3.0-cp39-abi3-win_amd64.whl", hash = "sha256:a2cd125adccf7969470621905d302750cd25951f22ea430d9a25b7be031e5549", size = 1105561, upload-time = "2026-04-30T23:24:44.578Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/46/d3ec57ad500f598d1554bd14ce4df615960549ab2844961bc4e1f5fbd174/ast_serialize-0.3.0-cp39-abi3-win_arm64.whl", hash = "sha256:0dd00da29985f15f50dc35728b7e1e7c84507bccfea1d9914738530f1c72238a", size = 1077165, upload-time = "2026-04-30T23:24:46.377Z" },
 ]
 
 [[package]]
@@ -224,12 +266,94 @@ wheels = [
 ]
 
 [[package]]
+name = "librt"
+version = "0.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/39/cb/c1945e506893b5b8577fb45a60c80e3ffe4a82092a04a6f29b0b951d9a24/librt-0.10.0.tar.gz", hash = "sha256:1aba1e8aa4e3307a7be68a74149545fde7451964dc0235a8bec5704a17bdda42", size = 191799, upload-time = "2026-05-05T16:31:23.535Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/64/7165e08108cc185a13a9c069f0685e6ef92e70e07fddf7edf5e7348c6316/librt-0.10.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:f09588a30e6a22ec624090d72a3ab1a6d4d5485c3ed739603e76aa3c16efa688", size = 76794, upload-time = "2026-05-05T16:30:20.392Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/ef/bf8613febf651b90c5222ee79dea5ae58d4cc2b544df69d3033424448934/librt-0.10.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:131ade118d12bd7a0adc4e655474a553f1b76cf78385868885944d21d51e45e0", size = 79662, upload-time = "2026-05-05T16:30:22.025Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/67/9eddd165c1d8397bdf99b38bf12b5a55b3def5035b49eedb49f2775d1430/librt-0.10.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b8b9ab28e40d011c373a189eae900c916e66d6fbecf7983e9e4883089ee085ef", size = 242390, upload-time = "2026-05-05T16:30:23.51Z" },
+    { url = "https://files.pythonhosted.org/packages/10/d1/d95da80334501866cd37004ab5d7483220d05862fab4b5405394f0264f0d/librt-0.10.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:67c39bb30da73bae1f293d1ed8bc2f8f6642649dd0928d3600aeff3041ac23d6", size = 232603, upload-time = "2026-05-05T16:30:25.198Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/fa/e6d64d28718bc1be4e1736fcb037ca1c4dfca927e7167df75a7d5215665e/librt-0.10.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8c3273c6b774614f093c8927c2bf1b077d0fefde988fe98f46a333734e5597ab", size = 259187, upload-time = "2026-05-05T16:30:26.772Z" },
+    { url = "https://files.pythonhosted.org/packages/72/3f/3fdb77e7f937dad59cfd76b720be7e7643400ec76b2da35befab8d66ba30/librt-0.10.0-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9dd7c1b86a4baa583ab5db977484b93a2c474e69e96ef3e9538387ea54229cb9", size = 251846, upload-time = "2026-05-05T16:30:28.56Z" },
+    { url = "https://files.pythonhosted.org/packages/18/ca/f4d49133dd86a6f55d79eca30bf412fa722f511a9abe67f62f57aa64e66a/librt-0.10.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a77385c5a202e831149f7ad03be9e67cf80e957e52c614e83dcb822c95222eb8", size = 264936, upload-time = "2026-05-05T16:30:30.491Z" },
+    { url = "https://files.pythonhosted.org/packages/de/66/a8df2fbadc1f6c1827a096d11c40175bd526133480bd3bc88ec64a03d257/librt-0.10.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:c6a5eafa74b5655bad59886138ed68426f098a6beb8cb95a71f2cc3cd8bb33fe", size = 258699, upload-time = "2026-05-05T16:30:32.002Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/73/1e3c83613fe05451bb969e27b68a573d177f08d5f63533cc29fec0989658/librt-0.10.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:1fc93d0439204c50ab4d1512611ce2c206f1b369b419f69c7c27c761561e3291", size = 259825, upload-time = "2026-05-05T16:30:35.077Z" },
+    { url = "https://files.pythonhosted.org/packages/09/24/5e2f926ee9d3ef348d9339526d7062abb5c44d8419e3179528c01d78c102/librt-0.10.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:79e713c178bc7a744adfbee6b4619a288eecc0c914da2a9313a20255abe2f0cf", size = 282548, upload-time = "2026-05-05T16:30:36.639Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/7d/3e89ed6ad0162561fa8bef9df3195e24263104c955713cd0237d3711fad2/librt-0.10.0-cp314-cp314-win32.whl", hash = "sha256:2eba9d955a68c41d9f326be3da42f163ec3518b7ab20f1c826224e7bed71e0bf", size = 58970, upload-time = "2026-05-05T16:30:38.183Z" },
+    { url = "https://files.pythonhosted.org/packages/76/25/579e731c94a7086a268bfa3e7a4945cd47836bebd3cbf3faeafd2e7eaef9/librt-0.10.0-cp314-cp314-win_amd64.whl", hash = "sha256:cbfaf7f5145e9917f5d18bffa298eff6a19d74e7b8b11dabdca95785befe8dbf", size = 67260, upload-time = "2026-05-05T16:30:39.804Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/f8/235822b7ae0b2334f12ee18bcf2476d07924077a5efeea57dbe927704be2/librt-0.10.0-cp314-cp314-win_arm64.whl", hash = "sha256:8d6d385d1969849a6b1397114df22714b6ded917bada98668e3e974dc663477e", size = 57156, upload-time = "2026-05-05T16:30:41.412Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/e3/9b919cbf1e8eb770bf91bb7df28125e0f1daf4587169afefd95402636e9a/librt-0.10.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:6c3a82d3bd32631ef5c79922dfc028520c9ad840255979ab4d908271818039ee", size = 79150, upload-time = "2026-05-05T16:30:42.761Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/f5/72a944aa3bc3498169a168087eff58ca48b58bf1b704e59d091fd30739f3/librt-0.10.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:d64cc66005dc324c9bb1fa3fc2841f529002f6eb15966d55e46d430f56955a6a", size = 82304, upload-time = "2026-05-05T16:30:44.082Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/e3/fcc290a33e295019759472dfa794d204e43504b276ac65eab7fd9da20ea3/librt-0.10.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9bb562cd28c88cd2c6a9a6c78f99dc39348d6b16c94adc25de0e574acf1176e9", size = 272556, upload-time = "2026-05-05T16:30:45.497Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/54/546975e4c997573885e7f040a05012f8838e06fb12b0c3c1fbb76254e9d7/librt-0.10.0-cp314-cp314t-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:b809aa2854d019c28773b03605df22adc675ee4f3f4402d673581313e8906119", size = 256941, upload-time = "2026-05-05T16:30:47.059Z" },
+    { url = "https://files.pythonhosted.org/packages/70/8c/f1d03401571b331653acddbd4e8cd955c06d945241dd08b25192fac0d04b/librt-0.10.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cc15acabdd519bd4176fdadc2119e5e3093485d86f89138daf47e5b4cedb983a", size = 285855, upload-time = "2026-05-05T16:30:48.86Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/08/62cf80ff046c339faf56718b3a940244d4beb70f1c6407289b5830ec11e9/librt-0.10.0-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b1b2d835307d08ddadd94568e2369648ec9173bd3eea6d7f52a1abe717c81f98", size = 275321, upload-time = "2026-05-05T16:30:50.63Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/ea/da5918d4070362e9a4d2ee9cd34f9dc84902daad8fd4275f8504a727ff4e/librt-0.10.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d261c6a2f93335a5167887fb0223e8b98ffce20ee3fde242e8e58a37ece6d0e5", size = 293993, upload-time = "2026-05-05T16:30:52.577Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/8d/68b6086bed1fcdc314c640ea04e31e52d18052e08059fa595409d66a51a9/librt-0.10.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:e2ffd44963f8e7f68995504d90f9881d64e94dc1d8e310039b9526108fc0c0f7", size = 284254, upload-time = "2026-05-05T16:30:55.086Z" },
+    { url = "https://files.pythonhosted.org/packages/06/c8/b810f1d84ec34a5a7ed93d7b510ab04164d75fbdf23088d5c3fbe6b08357/librt-0.10.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:5f285f6455ed495791c4d8630e5af732960adea93cac4c893d15619f2eae53e8", size = 284925, upload-time = "2026-05-05T16:30:56.728Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/00/3c82d4158c5a2c62528b8fccce65a8c9ad700e480e86f9389387435089a5/librt-0.10.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:f6034ff52e663d34c7b82ef2aa2f94ad7c1d939e2368e63b06844bc4d127d2e1", size = 307830, upload-time = "2026-05-05T16:30:58.377Z" },
+    { url = "https://files.pythonhosted.org/packages/99/3a/9c635ac3e8a00383ff689161d3eac8a30b3b2ddc711b40471e6b8983ea29/librt-0.10.0-cp314-cp314t-win32.whl", hash = "sha256:657860fd877fba6a241ea088ef99f63ca819945d3c715265da670bad56c37ebe", size = 60147, upload-time = "2026-05-05T16:31:00.293Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/e8/6f65f3e565d4ac212cddddd552eacc8035ffdf941ca0ad6fe945a211d41f/librt-0.10.0-cp314-cp314t-win_amd64.whl", hash = "sha256:56ded2d66010203a0cb5af063b609e3f079531a0e5e576d618dece859fd2e1af", size = 68649, upload-time = "2026-05-05T16:31:01.778Z" },
+    { url = "https://files.pythonhosted.org/packages/51/78/a0705a67cacd81e5fa01a5035b3adbdfbb43a7b8d4bd27e2b282ae61baf2/librt-0.10.0-cp314-cp314t-win_arm64.whl", hash = "sha256:1ee63f30abf18ed4830fdbaf87b2b6f4bba1e198d46085c314edde4045e56715", size = 58247, upload-time = "2026-05-05T16:31:03.191Z" },
+]
+
+[[package]]
+name = "mypy"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ast-serialize" },
+    { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "mypy-extensions" },
+    { name = "pathspec" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cf/dc/7e6d49f04fca40b9dd5c752a51a432ffe67fb45200702bc9eee0cb4bbb26/mypy-2.0.0.tar.gz", hash = "sha256:1a9e3900ac5c40f1fe813506c7739da6e6f0eab2729067ebd94bfb0bbba53532", size = 3869036, upload-time = "2026-05-06T19:26:43.22Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/2c/6fefe954207860aed6eeb91776795e64a257d3ce0360862288984ce121f5/mypy-2.0.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:c918c64e8ce36557851b0347f84eb12f1965d3a06813c36df253eb0c0afd1d82", size = 14729633, upload-time = "2026-05-06T19:24:53.383Z" },
+    { url = "https://files.pythonhosted.org/packages/23/d6/d336f5b820af189eb0390cce21de62d264c0a4e64713dfbe81bfc4fc7739/mypy-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:301f1a8ccc7d79b542ee218b28bb49443a83e194eb3d10da63ff1649e5aa5d34", size = 13559524, upload-time = "2026-05-06T19:22:24.906Z" },
+    { url = "https://files.pythonhosted.org/packages/af/a6/d7bb54fde1770f0484e5fbdbdce37a41e95ed0a1cd493ec60ead111e356c/mypy-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fdf4ef489d44ce350bac3fd699907834e551d4c934e9cc862ef201215ab1558d", size = 13936018, upload-time = "2026-05-06T19:25:02.992Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/ba/5be51316b91e6a6bf6e3a8adb3de500e7e1fb5bf9491743b8cbc81a34a2c/mypy-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9cde2d0989f912fc850890f727d0d76495e7a6c5bdd9912a1efdb64952b4398d", size = 14910712, upload-time = "2026-05-06T19:25:21.83Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/37/e2c8c3b373e20ebfb66e6c83a99027fd67df4ec43b08879f74e822d2dc4c/mypy-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:cdf05693c231a14fe37dbfce192a3a1372c26a833af4a80f550547742952e719", size = 15141499, upload-time = "2026-05-06T19:20:50.924Z" },
+    { url = "https://files.pythonhosted.org/packages/12/36/07756f933e00416d912e35878cfcf89a593a3350a885691c0bb85ae0226a/mypy-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:73aee2da33a2237e66cbe84a94780e53599847e86bb3aa7b93e405e8cd9905f2", size = 11240511, upload-time = "2026-05-06T19:21:32.39Z" },
+    { url = "https://files.pythonhosted.org/packages/70/05/79ac1f20f2397353f3845f7b8bb5d8006cda7c8ef9092f04f9de3c6135f2/mypy-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:1f6dcd8f39971f41edab2728c877c4ac8b50ad3c387ff2770423b79a05d23910", size = 10149336, upload-time = "2026-05-06T19:22:08.383Z" },
+    { url = "https://files.pythonhosted.org/packages/53/e0/0db84e0ebbad6e99e566c68e4b465784f2a2294f7719e8db9d509ef23087/mypy-2.0.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:a04e980b9275c76159da66c6e1723c7798306f9802b31bdaf9358d0c84030ce8", size = 15797362, upload-time = "2026-05-06T19:22:00.835Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/a4/14cc0768164dd53bec48aa41a20270b18df9bf72aa5054278bf133608315/mypy-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:33f9cf4825469b2bc73c53ba55f6d9a9b4cdb60f9e6e228745581520f29b8771", size = 14635914, upload-time = "2026-05-06T19:23:43.675Z" },
+    { url = "https://files.pythonhosted.org/packages/08/48/d866a3e23b4dc5974c77d9cf65a435bf22de01a84dd4620917950e233960/mypy-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:191675c3c7dc2a5c7722a035a6909c277f14046c5e4e02aa5fbf65f8524f08ad", size = 15270866, upload-time = "2026-05-06T19:22:34.756Z" },
+    { url = "https://files.pythonhosted.org/packages/71/eb/de9ef94958eb2078a6b908ceb247757dc384d3a238d3bd6ed7d81de5eaf8/mypy-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c3d26c4321a3b06fc9f04c741e0733af693f82d823f8e64e47b2e63b7f19fa84", size = 16093131, upload-time = "2026-05-06T19:23:56.541Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/07/0ab2c1a9d26e90942612724cbd5788f16b7810c5dd39bfcf79286c6c4524/mypy-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:bbcbc4d5917ca6ce12de70e051de7f533e3bf92d548b41a38a2232a6fe356525", size = 16330685, upload-time = "2026-05-06T19:21:42.037Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/8f/46f85d1371a5be642dad263828118ae1efd536d91d8bd2000c68acff3920/mypy-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:dbc6ba6d40572ae49268531565793a8f07eac7fc65ad76d482c9b4c8765b6043", size = 12752017, upload-time = "2026-05-06T19:22:44.002Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/e6/94ca48800cac19eb28a58188a768aaec0d16cac0f373915f073058ab0855/mypy-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:77926029dfcb7e1a3ecb0acb2ddbb24ca36be03f7d623e1759ad5376be8f6c01", size = 10527097, upload-time = "2026-05-06T19:20:58.973Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/14/fd0694aa594d6e9f9fd16ce821be2eff295197a273262ef56ddcc1388d68/mypy-2.0.0-py3-none-any.whl", hash = "sha256:8a92b2be3146b4fa1f062af7eb05574cbf3e6eb8e1f14704af1075423144e4e5", size = 2673434, upload-time = "2026-05-06T19:26:32.856Z" },
+]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "25.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
 ]
 
 [[package]]
@@ -405,6 +529,31 @@ wheels = [
 ]
 
 [[package]]
+name = "ruff"
+version = "0.15.12"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/99/43/3291f1cc9106f4c63bdce7a8d0df5047fe8422a75b091c16b5e9355e0b11/ruff-0.15.12.tar.gz", hash = "sha256:ecea26adb26b4232c0c2ca19ccbc0083a68344180bba2a600605538ce51a40a6", size = 4643852, upload-time = "2026-04-24T18:17:14.305Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/6e/e78ffb61d4686f3d96ba3df2c801161843746dcbcbb17a1e927d4829312b/ruff-0.15.12-py3-none-linux_armv6l.whl", hash = "sha256:f86f176e188e94d6bdbc09f09bfd9dc729059ad93d0e7390b5a73efe19f8861c", size = 10640713, upload-time = "2026-04-24T18:17:22.841Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/08/a317bc231fb9e7b93e4ef3089501e51922ff88d6936ce5cf870c4fe55419/ruff-0.15.12-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:e3bcd123364c3770b8e1b7baaf343cc99a35f197c5c6e8af79015c666c423a6c", size = 11069267, upload-time = "2026-04-24T18:17:30.105Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/a4/f828e9718d3dce1f5f11c39c4f65afd32783c8b2aebb2e3d259e492c47bd/ruff-0.15.12-py3-none-macosx_11_0_arm64.whl", hash = "sha256:fe87510d000220aa1ed530d4448a7c696a0cae1213e5ec30e5874287b66557b5", size = 10397182, upload-time = "2026-04-24T18:17:07.177Z" },
+    { url = "https://files.pythonhosted.org/packages/71/e0/3310fc6d1b5e1fdea22bf3b1b807c7e187b581021b0d7d4514cccdb5fb71/ruff-0.15.12-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:84a1630093121375a3e2a95b4a6dc7b59e2b4ee76216e32d81aae550a832d002", size = 10758012, upload-time = "2026-04-24T18:16:55.759Z" },
+    { url = "https://files.pythonhosted.org/packages/11/c1/a606911aee04c324ddaa883ae418f3569792fd3c4a10c50e0dd0a2311e1e/ruff-0.15.12-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fb129f40f114f089ebe0ca56c0d251cf2061b17651d464bb6478dc01e69f11f5", size = 10447479, upload-time = "2026-04-24T18:16:51.677Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/68/4201e8444f0894f21ab4aeeaee68aa4f10b51613514a20d80bd628d57e88/ruff-0.15.12-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b0c862b172d695db7598426b8af465e7e9ac00a3ea2a3630ee67eb82e366aaa6", size = 11234040, upload-time = "2026-04-24T18:17:16.529Z" },
+    { url = "https://files.pythonhosted.org/packages/34/ff/8a6d6cf4ccc23fd67060874e832c18919d1557a0611ebef03fdb01fff11e/ruff-0.15.12-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2849ea9f3484c3aca43a82f484210370319e7170df4dfe4843395ddf6c57bc33", size = 12087377, upload-time = "2026-04-24T18:17:04.944Z" },
+    { url = "https://files.pythonhosted.org/packages/85/f6/c669cf73f5152f623d34e69866a46d5e6185816b19fcd5b6dd8a2d299922/ruff-0.15.12-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9e77c7e51c07fe396826d5969a5b846d9cd4c402535835fb6e21ce8b28fef847", size = 11367784, upload-time = "2026-04-24T18:17:25.409Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/39/c61d193b8a1daaa8977f7dea9e8d8ba866e02ea7b65d32f6861693aa4c12/ruff-0.15.12-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:83b2f4f2f3b1026b5fb449b467d9264bf22067b600f7b6f41fc5958909f449d0", size = 11344088, upload-time = "2026-04-24T18:17:12.258Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/8d/49afab3645e31e12c590acb6d3b5b69d7aab5b81926dbaf7461f9441f37a/ruff-0.15.12-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:9ba3b8f1afd7e2e43d8943e55f249e13f9682fde09711644a6e7290eb4f3e339", size = 11271770, upload-time = "2026-04-24T18:17:02.457Z" },
+    { url = "https://files.pythonhosted.org/packages/46/06/33f41fe94403e2b755481cdfb9b7ef3e4e0ed031c4581124658d935d52b4/ruff-0.15.12-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:e852ba9fdc890655e1d78f2df1499efbe0e54126bd405362154a75e2bde159c5", size = 10719355, upload-time = "2026-04-24T18:17:27.648Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/59/18aa4e014debbf559670e4048e39260a85c7fcee84acfd761ac01e7b8d35/ruff-0.15.12-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:dd8aed930da53780d22fc70bdf84452c843cf64f8cb4eb38984319c24c5cd5fd", size = 10462758, upload-time = "2026-04-24T18:17:32.347Z" },
+    { url = "https://files.pythonhosted.org/packages/25/e7/cc9f16fd0f3b5fddcbd7ec3d6ae30c8f3fde1047f32a4093a98d633c6570/ruff-0.15.12-py3-none-musllinux_1_2_i686.whl", hash = "sha256:01da3988d225628b709493d7dc67c3b9b12c0210016b08690ef9bd27970b262b", size = 10953498, upload-time = "2026-04-24T18:17:20.674Z" },
+    { url = "https://files.pythonhosted.org/packages/72/7a/a9ba7f98c7a575978698f4230c5e8cc54bbc761af34f560818f933dafa0c/ruff-0.15.12-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:9cae0f92bd5700d1213188b31cd3bdd2b315361296d10b96b8e2337d3d11f53e", size = 11447765, upload-time = "2026-04-24T18:17:09.755Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/f9/0ae446942c846b8266059ad8a30702a35afae55f5cdc54c5adf8d7afdc27/ruff-0.15.12-py3-none-win32.whl", hash = "sha256:d0185894e038d7043ba8fd6aee7499ece6462dc0ea9f1e260c7451807c714c20", size = 10657277, upload-time = "2026-04-24T18:17:18.591Z" },
+    { url = "https://files.pythonhosted.org/packages/33/f1/9614e03e1cdcbf9437570b5400ced8a720b5db22b28d8e0f1bda429f660d/ruff-0.15.12-py3-none-win_amd64.whl", hash = "sha256:c87a162d61ab3adca47c03f7f717c68672edec7d1b5499e652331780fe74950d", size = 11837758, upload-time = "2026-04-24T18:17:00.113Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/98/6beb4b351e472e5f4c4613f7c35a5290b8be2497e183825310c4c3a3984b/ruff-0.15.12-py3-none-win_arm64.whl", hash = "sha256:a538f7a82d061cee7be55542aca1d86d1393d55d81d4fcc314370f4340930d4f", size = 11120821, upload-time = "2026-04-24T18:16:57.979Z" },
+]
+
+[[package]]
 name = "sniffio"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -429,6 +578,12 @@ test = [
     { name = "pytest-xdist" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "mypy" },
+    { name = "ruff" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "google-genai", specifier = ">=1.19.0" },
@@ -438,6 +593,12 @@ requires-dist = [
     { name = "python-dotenv", specifier = ">=1.0.0" },
 ]
 provides-extras = ["test"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "mypy", specifier = ">=2.0.0" },
+    { name = "ruff", specifier = ">=0.15.12" },
+]
 
 [[package]]
 name = "tenacity"


### PR DESCRIPTION
## Problem

The STT daemon reached 18GB memory during extended operation as a background service.

## Root Causes & Fixes

| Root Cause | Fix |
|---|---|
| `asyncio.run()` per transcription — creates/destroys event loops, leaking client connections | Persistent event loop in daemon thread + `asyncio.run_coroutine_threadsafe()` |
| Duplicate `genai.Client` instances (`_client` + `_live_client`) — double HTTP pools | Single unified `_client` with v1beta API version (backward compatible) |
| Audio data duplication (`f.read()` + `Part.from_bytes()` = 2x in memory) | `del audio_data` immediately after Part creation |
| No GC after transcription — memory sits fragmented | `gc.collect()` in `finally` block after each cycle |
| No client cleanup on shutdown — connection pools never closed | `close()` methods (idempotent) called in `_cleanup()` |
| No memory monitoring | Periodic RSS logging every ~60 seconds |

## Additional Improvements

- 120s timeout on `future.result()` to prevent infinite hangs
- Idempotent `close()` — safe to call multiple times
- Tests updated for unified client architecture

## Testing

- 160/166 tests pass (6 pre-existing failures due to missing system audio deps)
- Code review passed (quality, guidelines, security)

## New Features (added in this PR)

### Max Recording Duration (Closes #11)

| Feature | Details |
|---|---|
| Default max duration | 5 minutes (300 seconds) |
| Configuration | `STT_MAX_RECORDING` env var |
| Behavior | Auto-stops recording when limit reached |
| Notification | Desktop notification when auto-stopped |
| Validation | Invalid/negative values fall back to default |

### Real-Time Streaming Transcription (`--live` mode)

Previously `--live` recorded the full audio first, then streamed the pre-recorded WAV. Now:

| Before | After |
|---|---|
| Record WAV → Stop → Read file → Stream to API | Start recording → Stream PCM chunks to API **while recording** → Stop → Collect result |

- `AudioRecorder.start_streaming()` — records raw PCM to stdout pipe with background reader thread
- `GeminiLiveTranscriber.start_streaming(recorder)` / `.stop_streaming()` — manages real-time WebSocket session
- Audio chunks are streamed to Gemini Live API as they arrive (32KB chunks)
- Daemon orchestrates streaming recording + transcription simultaneously in `--live` mode

Closes #11

Closes #15