### PR TITLE
chore: bump version to 0.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "stt-wayland"
-version = "0.1.0"
+version = "0.2.0"
 description = "Wayland-native Speech-to-Text daemon"
 readme = "README.md"
 requires-python = ">=3.14"

--- a/src/stt_wayland/__init__.py
+++ b/src/stt_wayland/__init__.py
@@ -1,3 +1,3 @@
 """Wayland-native Speech-to-Text daemon."""
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -564,7 +564,7 @@ wheels = [
 
 [[package]]
 name = "stt-wayland"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "google-genai" },


### PR DESCRIPTION
Bump version from 0.1.0 to 0.2.0 in pyproject.toml, __init__.py, and uv.lock.